### PR TITLE
The id must be an int!

### DIFF
--- a/ckanext/versioned_datastore/lib/ingestion/feeders.py
+++ b/ckanext/versioned_datastore/lib/ingestion/feeders.py
@@ -69,7 +69,7 @@ class DatastoreFeeder(IngestionFeeder):
         # if the record has an _id column then we use it, if it doesn't then we just use the index
         # of the record in the source plus the offset value. This accommodates the simple scenario
         # where the source data dicts don't have ids and the user just wants to add to the existing
-        record_id = data.pop(u'_id', self.id_offset + number)
+        record_id = int(data.pop(u'_id', self.id_offset + number))
         return DatastoreRecord(self.version, record_id, data, self.resource_id)
 
 


### PR DESCRIPTION
The id must be stored in mongo as an integer, so here we force it. This came up because I created a resource from a csv without an _id field and then updated it with a new version where the _id was set. Under these
circumstances the _id is read as a string and therefore needs to be converted to an int before storage, otherwise you end up with some records where the id in mongo is an int and some where it's a string, blargh! Currently this is not a problem in the live mongo database so we can safely make this change without breaking anything, so that's lucky.

In the future, it'd be far better to validate the source before ingestion, or have a way of rolling back, however with the current version of ckan the first part of this would be a nightmare and as for the second part, that needs to be implemented in eevee (probably) but would require a reasonable effort to get right. The reason I mention this is because if a user uploads a file with an _id field that isn't convertable to an int then this change will throw a ValueError. It's better to be thrown here than thrown during indexing but it leaves the user in a strange state where some of the data may have been ingested which isn't ideal. Anyway, future problems...