### PR TITLE
Improve the datastore page's styling

### DIFF
--- a/ckanext/versioned_datastore/helpers.py
+++ b/ckanext/versioned_datastore/helpers.py
@@ -1,0 +1,97 @@
+from ckan.plugins import toolkit
+from ckanext.versioned_datastore.lib import stats
+
+
+def is_duplicate_ingestion(stat):
+    '''
+    Detects whether the error message on this ImportStats object is a DuplicateDataSource error
+    message or not. This is based on the error containing the phrase "this file has been ingested
+    before" and is therefore a quite fragile, but it's only for UI purposes so it's not he end of
+    the world if it produces a few false positives/negatives.
+
+    :param stat: the ImportStats object
+    :return: True if the error on this stat is a duplicate ingestion error, False if not
+    '''
+    return stat.error and u'this file has been ingested before' in stat.error.lower()
+
+
+def get_human_duration(stat):
+    '''
+    Get the duration on the passed ImportStats object in a sensible human readable format. The
+    duration on stats objects is in seconds and therefore is great for small values but horrendous
+    if it took 20 minutes. The output from this function is a string with either the number of
+    seconds (to 2 decimal places), the number of minutes (to 0 decimal places) or the number of
+    hours (to 0 decimal places).
+
+    :param stat: the ImportStats object
+    :return: a nicely formatted duration string
+    '''
+    if stat.duration < 60:
+        return toolkit._(u'{:.2f} seconds'.format(stat.duration))
+    elif stat.duration < 60 * 60:
+        return toolkit._(u'{:.0f} minutes'.format(stat.duration / 60))
+    else:
+        return toolkit._(u'{:.0f} hours'.format(stat.duration / (60 * 60)))
+
+
+def get_stat_icon(stat):
+    '''
+    Returns the fontawesome icon class(-es) to be used for the given ImportStats object. The return
+    value is based on the type of stat and other factors like whether the operation the stat
+    represents is still in progress.
+
+    :param stat: the ImportStats object
+    :return: the fontawesome icon classes to use, as a string
+    '''
+    if stat.in_progress:
+        # a spinner, that spins
+        return u'fa-spinner fa-pulse'
+    if stat.error:
+        if is_duplicate_ingestion(stat):
+            # we don't want this to look like an error
+            return u'fa-copy'
+        return u'fa-exclamation'
+
+    if stat.type == stats.INGEST:
+        return u'fa-tasks'
+    if stat.type == stats.INDEX:
+        return u'fa-search'
+    if stat.type == stats.PREP:
+        return u'fa-cogs'
+    # shouldn't get here, just use some default tick thing
+    return u'fa-check'
+
+
+def get_stat_activity_class(stat):
+    '''
+    Returns the activity css class to use for the given ImportStats object. The return value is a
+    string css class which either matches one of the activity item classes from core ckan or matches
+    one of the custom ones in this extension's css.
+
+    :param stat: the ImportStats object
+    :return: a string
+    '''
+    if stat.in_progress:
+        return u'in_progress'
+    if stat.error:
+        if is_duplicate_ingestion(stat):
+            return u'duplicate'
+        return u'failure'
+    return stat.type
+
+
+def get_stat_title(stat):
+    '''
+    Returns the title to use for the activity item created for the given ImportStats object. This is
+    based on the stat's type.
+
+    :param stat: the ImportStats object
+    :return: the title for the activity item as a unicode string
+    '''
+    if stat.type == stats.INGEST:
+        return toolkit._(u'Ingested new resource data')
+    if stat.type == stats.INDEX:
+        return toolkit._(u'Updated search index with resource data')
+    if stat.type == stats.PREP:
+        return toolkit._(u'Validated and prepared the data for ingestion')
+    return stat.type

--- a/ckanext/versioned_datastore/lib/ingestion/exceptions.py
+++ b/ckanext/versioned_datastore/lib/ingestion/exceptions.py
@@ -54,3 +54,25 @@ class DuplicateDataSource(IngestionException):
         super(DuplicateDataSource, self).__init__(
             u'This file has been ingested before, ignoring [hash: {}]'.format(file_hash))
         self.file_hash = file_hash
+
+
+class InvalidCharacterException(IngestionException):
+    '''
+    Thrown when there is an invalid unicode character found in the resource data. This is detected
+    by checking if the unicode version of the row contains any category C characters (control
+    characters basically, see here: http://www.unicode.org/reports/tr44/#General_Category_Values).
+    This is treated as an error to avoid putting crap unicode into the jsonl.gz intermediate file
+    and then erroring when attempting to deserialise the json.
+    Typically this error is produced when the user has uploaded a file in a really weird character
+    encoding and we failed to detect it, thus falling back to UTF-8.
+    '''
+
+    def __init__(self, row_number, row):
+        '''
+        :param row_number: the row number (1-indexed, excluding the header)
+        :param row: the row (this should be a dict
+        '''
+        message = u'Row {} (excluding header) contained an invalid character'.format(row_number)
+        super(InvalidCharacterException, self).__init__(message)
+        self.row_number = row_number
+        self.row = row

--- a/ckanext/versioned_datastore/lib/ingestion/exceptions.py
+++ b/ckanext/versioned_datastore/lib/ingestion/exceptions.py
@@ -11,12 +11,13 @@ class UnsupportedDataSource(IngestionException):
     the format isn't one we support.
     '''
 
-    def __init__(self, url):
+    def __init__(self, res_format):
         '''
-        :param url: the url that couldn't be ingested
+        :param res_format: the resource format
         '''
-        super(UnsupportedDataSource, self).__init__(u'Could not find reader for {}'.format(url))
-        self.url = url
+        super(UnsupportedDataSource, self).__init__(
+            u'Could not find ingest reader for {}'.format(res_format if res_format else u'n/a'))
+        self.res_format = res_format
 
 
 class InvalidId(IngestionException):

--- a/ckanext/versioned_datastore/lib/ingestion/ingesting.py
+++ b/ckanext/versioned_datastore/lib/ingestion/ingesting.py
@@ -269,7 +269,7 @@ def get_fp_and_reader_for_resource_data(resource, data=None, api_key=None):
         handled = True
 
     if not handled:
-        raise exceptions.UnsupportedDataSource(resource[u'url'])
+        raise exceptions.UnsupportedDataSource(resource.get(u'format', None))
 
 
 class DatastoreFeeder(IngestionFeeder):

--- a/ckanext/versioned_datastore/lib/ingestion/ingesting.py
+++ b/ckanext/versioned_datastore/lib/ingestion/ingesting.py
@@ -299,7 +299,7 @@ class DatastoreFeeder(IngestionFeeder):
                 # skip the first line
                 next(reader)
             for line in reader:
-                yield simplejson.loads(line, encoding=u'utf-8')
+                yield simplejson.loads(line)
 
     def get_existing_max_id(self):
         '''

--- a/ckanext/versioned_datastore/lib/ingestion/ingesting.py
+++ b/ckanext/versioned_datastore/lib/ingestion/ingesting.py
@@ -58,7 +58,7 @@ def ingest_resource(version, config, resource, data, replace, api_key):
             # these exceptions are expected (validation problems for example)
             return False
         else:
-            raise e
+            raise
     else:
         stats.finish_operation(prep_stats_id, data_file_metadata[u'record_count'])
 

--- a/ckanext/versioned_datastore/lib/ingestion/readers.py
+++ b/ckanext/versioned_datastore/lib/ingestion/readers.py
@@ -23,7 +23,7 @@ def get_reader(resource_format):
     resource_format = resource_format.lower()
     if resource_format in utils.CSV_FORMATS:
         return SVReader(u'excel')
-    if resource_format == utils.TSV_FORMATS:
+    if resource_format in utils.TSV_FORMATS:
         return SVReader(u'excel-tab')
     if resource_format in utils.XLS_FORMATS:
         return XLSReader()

--- a/ckanext/versioned_datastore/lib/ingestion/readers.py
+++ b/ckanext/versioned_datastore/lib/ingestion/readers.py
@@ -7,7 +7,7 @@ import six
 import xlrd
 from cchardet import UniversalDetector
 from ckanext.versioned_datastore.lib import utils
-from ckanext.versioned_datastore.lib.ingestion.utils import ensure_reset
+from ckanext.versioned_datastore.lib.ingestion.utils import ensure_reset, iter_universal_lines
 from openpyxl.cell.read_only import EmptyCell
 from ckanext.versioned_datastore.lib.ingestion import exceptions
 
@@ -133,7 +133,8 @@ class SVReader(ResourceReader):
                 self.encoding = u'utf-8'
 
         # create and return the dict reader
-        return unicodecsv.DictReader(resource_data_fp, dialect=self.dialect, encoding=self.encoding)
+        line_iterator = iter_universal_lines(resource_data_fp, self.encoding)
+        return unicodecsv.DictReader(line_iterator, dialect=self.dialect, encoding=self.encoding)
 
     def _get_rows(self, resource_data_fp):
         '''

--- a/ckanext/versioned_datastore/lib/ingestion/utils.py
+++ b/ckanext/versioned_datastore/lib/ingestion/utils.py
@@ -130,3 +130,35 @@ class InclusionTracker(object):
             cursor = self.tracker_db.cursor()
             cursor.execute(u'select 1 from ids where id = ?', (record_id,))
             return cursor.fetchone() is not None
+
+
+def iter_universal_lines(fp, read_size=65536):
+    '''
+    Given a file object, read data from it, convert various newline types to \n and then yield
+    lines as strings (i.e. bytes in python2). This is a way round the problem of not being able to
+    reopen a file already opened in rb mode in rU mode. The line endings recognised by this function
+    are "\n", "\r" and "\r\n".
+
+    :param fp: the file object to read from, this must be open in rb mode
+    :param read_size: the number of bytes to read at a time from the file object (default: 65536)
+    :return: a generator which yields lines as strings
+    '''
+    cache = b''
+    while True:
+        chunk = fp.read(read_size)
+        if chunk:
+            # switch the \r\n and \r line endings for \n endings
+            chunk = chunk.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
+            for character in chunk:
+                cache += character
+                if character == b'\n':
+                    # if the cache isn't just a new line, yield it
+                    if cache != b'\n':
+                        yield cache
+                    # reset the cache for the next line
+                    cache = b''
+        else:
+            # if there's any data left in the cache, yield it
+            if cache:
+                yield cache
+            break

--- a/ckanext/versioned_datastore/lib/stats.py
+++ b/ckanext/versioned_datastore/lib/stats.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-
-from sqlalchemy import desc
+from traceback import format_exception_only
 
 from ckan import model
 from ckanext.versioned_datastore.model.stats import ImportStats
-
+from datetime import datetime
+from sqlalchemy import desc
 
 PREP = u'prep'
 INGEST = u'ingest'
@@ -138,7 +137,7 @@ def mark_error(stats_id, error):
         ImportStats.in_progress: False,
         ImportStats.duration: (end - start).total_seconds(),
         ImportStats.end: end,
-        ImportStats.error: unicode(error.message),
+        ImportStats.error: unicode(format_exception_only(type(error), error)[-1].strip()),
     })
 
 

--- a/ckanext/versioned_datastore/plugin.py
+++ b/ckanext/versioned_datastore/plugin.py
@@ -8,7 +8,7 @@ from ckan.plugins import toolkit, interfaces, SingletonPlugin, implements
 from ckan.model import DomainObjectOperation
 from ckanext.versioned_datastore.lib.utils import is_datastore_resource, setup_eevee
 from ckanext.versioned_datastore.logic import action, auth
-from ckanext.versioned_datastore import routes
+from ckanext.versioned_datastore import routes, helpers
 
 log = logging.getLogger(__name__)
 
@@ -60,7 +60,12 @@ class VersionedSearchPlugin(SingletonPlugin):
     # ITemplateHelpers
     def get_helpers(self):
         return {
-            u'is_datastore_resource': is_datastore_resource
+            u'is_datastore_resource': is_datastore_resource,
+            u'is_duplicate_ingestion': helpers.is_duplicate_ingestion,
+            u'get_human_duration': helpers.get_human_duration,
+            u'get_stat_icon': helpers.get_stat_icon,
+            u'get_stat_activity_class': helpers.get_stat_activity_class,
+            u'get_stat_title': helpers.get_stat_title,
         }
 
     # IResourceController
@@ -119,6 +124,7 @@ class VersionedSearchPlugin(SingletonPlugin):
     def update_config(self, config):
         # add templates
         toolkit.add_template_directory(config, u'theme/templates')
+        toolkit.add_resource(u'theme/fanstatic', u'ckanext-versioned_datastore')
 
     ## IBlueprint
     def get_blueprint(self):

--- a/ckanext/versioned_datastore/theme/fanstatic/css/datastore-activities.css
+++ b/ckanext/versioned_datastore/theme/fanstatic/css/datastore-activities.css
@@ -1,0 +1,46 @@
+.activity .item .datastore_activity_title {
+    font-weight: bolder;
+}
+
+.activity .item.in_progress .icon {
+    background-color: #8c76ce;
+}
+
+.activity .item.duplicate .icon {
+    background-color: #b9b952;
+}
+
+.activity .item.ingest .icon {
+    background-color: #4c9947;
+}
+
+.activity .item.index .icon {
+    background-color: #4c9947;
+}
+
+.activity .item.prep .icon {
+    background-color: #4c9947;
+}
+
+.activity .item a {
+    font-size: 14px;
+    line-height: 1.5;
+    margin: 5px 0 0 80px;
+}
+
+.activity li:last-child {
+    /* this is a hack to prevent the dotted lines from displaying below the first activity */
+    background: white;
+}
+
+.activity .collapseDetails {
+    margin: 5px 0 0 100px;
+}
+
+.activity .collapseDetails .detailsTable {
+    font-size: 13px;
+}
+
+.activity .collapseDetails .detailsTable td {
+    padding-left: 12px;
+}

--- a/ckanext/versioned_datastore/theme/templates/package/resource_data.html
+++ b/ckanext/versioned_datastore/theme/templates/package/resource_data.html
@@ -1,5 +1,19 @@
 {% extends "package/resource_edit_base.html" %}
 
+{# if there is an operation in progress, refresh the page every 30 seconds #}
+{% if stats and stats[-1].in_progress %}
+{% set refresh_interval = 30 %}
+{% else %}
+{% set refresh_interval = 0 %}
+{% endif %}
+
+{% block meta %}
+    {{ super() }}
+    {% if refresh_interval > 0 %}
+        <meta http-equiv="refresh" content="{{ refresh_interval }}"/>
+    {% endif %}
+{% endblock %}
+
 {% block subtitle %}{{ h.dataset_display_name(pkg) }} - {{ h.resource_display_name(res) }}{% endblock %}
 
 {% block primary_content_inner %}
@@ -15,57 +29,56 @@
     {% endblock %}
 
     {% block datastore_history %}
-        <h3>{{ _('History') }}</h3>
-        <table class="table table-bordered">
-            <tr>
-                <th>{{ _('Status') }}</th>
-                <th>{{ _('Operation') }}</th>
-                <th>{{ _('Version') }}</th>
-                <th>{{ _('Start') }}</th>
-                <th>{{ _('End') }}</th>
-                <th>{{ _('Duration') }}</th>
-                <th>{{ _('Count') }}</th>
-                <th>{{ _('Error') }}</th>
-            </tr>
-            {% for stat in stats %}
-                <tr>
-                    <td>
-                        {% if stat.in_progress %}
-                            <i class="fas fa-spinner"></i>
-                        {% elif stat.error %}
-                            <i class="fas fa-exclamation"></i>
-                        {% else %}
-                            <i class="fas fa-check"></i>
-                        {% endif %}
-                    </td>
-                    <td>
-                        {% if stat.type == 'ingest' %}
-                            <i class="fas fa-tasks"></i>
-                        {% elif stat.type == 'index' %}
-                            <i class="fas fa-search"></i>
-                        {% endif %}
-                        {{ stat.type }}
-                    </td>
-                    <td>{{ stat.version }}</td>
-                    <td>{{ h.render_datetime(stat.start, with_hours=True) }}</td>
-                    <td>{{ h.render_datetime(stat.end, with_hours=True) }}</td>
-                    <td>
-                        {% if stat.duration %}
-                            {{ stat.duration }} seconds
-                        {% endif %}
-                    </td>
-                    <td>{{ stat.count }}</td>
-                    <td>
-                        {% if stat.error %}
-                            {{ stat.error }}
-                        {% else %}
-                            n/a
-                        {% endif %}
-                    </td>
-                </tr>
-            {% endfor %}
-        </table>
+        {% resource 'ckanext-versioned_datastore/css/datastore-activities.css' %}
 
+        <h3>{{ _('Datastore Activity') }}</h3>
+
+        <ul class="activity">
+            {% for stat in stats %}
+                <li class="item {{ h.get_stat_activity_class(stat) }}">
+                <i class="fa icon {{ h.get_stat_icon(stat) }}"></i>
+                <p>
+                    <span class="datastore_activity_title">{{ h.get_stat_title(stat) }}</span>
+                    <span class="date" title="{{ h.render_datetime(stat.start, with_hours=True) }}">{{ h.time_ago_from_timestamp(stat.start) }}</span>
+                </p>
+                <p>
+                    {% snippet 'package/snippets/' + stat.type + '_message.html', stat=stat %}
+                </p>
+                <a data-toggle="collapse" href="#collapseDetails{{ loop.index }}">
+                    {{ _("Show more details") }} <i class="fas fa-caret-down"></i>
+                </a>
+                <div class="collapse collapseDetails" id="collapseDetails{{ loop.index }}">
+                    <table class="detailsTable">
+                        <tr>
+                            <th>{{ _("Type") }}</th>
+                            <td>{{ stat.type }}</td>
+                        </tr>
+                        <tr>
+                            <th>{{ _("Version") }}</th>
+                            <td>{{ stat.version }}</td>
+                        </tr>
+                        <tr>
+                            <th>{{ _("Start") }}</th>
+                            <td>{{ stat.start }}</td>
+                        </tr>
+                        <tr>
+                            <th>{{ _("End") }}</th>
+                            <td>{{ stat.end }}</td>
+                        </tr>
+                    </table>
+                </div>
+                </li>
+            {% endfor %}
+        </ul>
     {% endblock %}
 
+    {% block refresh_warning %}
+        {% if refresh_interval > 0 %}
+            <i>
+            {% trans %}
+            This page will refresh every {{ refresh_interval }} seconds as there is an operation in progress
+            {% endtrans %}
+            </i>
+        {% endif %}
+    {% endblock %}
 {% endblock %}

--- a/ckanext/versioned_datastore/theme/templates/package/snippets/index_message.html
+++ b/ckanext/versioned_datastore/theme/templates/package/snippets/index_message.html
@@ -1,0 +1,17 @@
+<span class="datastore_activity_message">
+    {% if stat.error %}
+        {% trans error=stat.error %}
+        An error occurred during indexing: {{ error }}
+        {% endtrans %}
+    {% else %}
+        {% if stat.in_progress %}
+            {% trans count=stat.count %}
+            Indexing in progress, {{ count }} records processed so far
+            {% endtrans %}
+        {% else %}
+            {% trans count=stat.count, duration=h.get_human_duration(stat) %}
+            Indexed {{ count }} records in {{ duration }}
+            {% endtrans %}
+        {% endif %}
+    {% endif %}
+</span>

--- a/ckanext/versioned_datastore/theme/templates/package/snippets/ingest_message.html
+++ b/ckanext/versioned_datastore/theme/templates/package/snippets/ingest_message.html
@@ -1,0 +1,17 @@
+<span class="datastore_activity_message">
+    {% if stat.error %}
+        {% trans error=stat.error %}
+        An error occurred during ingestion: {{ error }}
+        {% endtrans %}
+    {% else %}
+        {% if stat.in_progress %}
+            {% trans count=stat.count %}
+            Ingestion in progress, {{ count }} records processed so far
+            {% endtrans %}
+        {% else %}
+            {% trans count=stat.count, duration=h.get_human_duration(stat) %}
+            Ingested {{ count }} records in {{ duration }}
+            {% endtrans %}
+        {% endif %}
+    {% endif %}
+</span>

--- a/ckanext/versioned_datastore/theme/templates/package/snippets/prep_message.html
+++ b/ckanext/versioned_datastore/theme/templates/package/snippets/prep_message.html
@@ -1,0 +1,17 @@
+<span class="datastore_activity_message">
+    {% if stat.error %}
+        {% trans error=stat.error %}
+        An error occurred during validation/preparation: {{ error }}
+        {% endtrans %}
+    {% else %}
+        {% if stat.in_progress %}
+            {% trans count=stat.count %}
+            Validation/preparation in progress, {{ count }} records processed so far
+            {% endtrans %}
+        {% else %}
+            {% trans count=stat.count, duration=h.get_human_duration(stat) %}
+            Validated and prepared {{ count }} records for ingestion in {{ duration }}
+            {% endtrans %}
+        {% endif %}
+    {% endif %}
+</span>

--- a/ckanext/versioned_datastore/theme/templates/package/snippets/prep_message.html
+++ b/ckanext/versioned_datastore/theme/templates/package/snippets/prep_message.html
@@ -1,8 +1,12 @@
 <span class="datastore_activity_message">
     {% if stat.error %}
-        {% trans error=stat.error %}
-        An error occurred during validation/preparation: {{ error }}
-        {% endtrans %}
+        {%  if h.is_duplicate_ingestion(stat) %}
+            This version of the resource data has been imported before, skipping
+        {% else %}
+            {% trans error=stat.error %}
+            An error occurred during validation/preparation: {{ error }}
+            {% endtrans %}
+        {% endif %}
     {% else %}
         {% if stat.in_progress %}
             {% trans count=stat.count %}


### PR DESCRIPTION
The table was horrible.

Now instead of something like this:

![before](https://user-images.githubusercontent.com/4718259/64349504-ff114a00-cfee-11e9-8c70-beb15c5b37bb.png)

You get something like this:

![after](https://user-images.githubusercontent.com/4718259/64349515-033d6780-cfef-11e9-8c73-1f0b1e800777.png)


There are a couple of other minor tweaks in this PR:

- fix TSV detection (https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/commit/6673f7468f0a65ff7042b481b16ebdd78d0bb412)
- fix universal lines issue (https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/commit/36d077ac8ee630e44abd51bdc4818e7572586d85)
- provide row count progress on prep operations (https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/commit/e2e84e1e815adde8c5e080c2a81d592c46f70927)
- try to catch rubbish unicode uploads (https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/commit/6f0ac4beb993b0806e56569ba542e8464889e665)
