### PR TITLE
Add a dedicated cross-resource counting action

### DIFF
--- a/ckanext/versioned_datastore/logic/auth.py
+++ b/ckanext/versioned_datastore/logic/auth.py
@@ -84,3 +84,9 @@ def datastore_search_raw(context, data_dict):
 def datastore_ensure_privacy(context, data_dict):
     # allow access to everyone
     return {u'success': True}
+
+
+@toolkit.auth_allow_anonymous_access
+def datastore_count(context, data_dict):
+    # allow access to everyone
+    return {u'success': True}

--- a/ckanext/versioned_datastore/logic/schema.py
+++ b/ckanext/versioned_datastore/logic/schema.py
@@ -183,3 +183,15 @@ def datastore_ensure_privacy_schema():
     return {
         u'resource_id': [ignore_missing, unicode, resource_id_exists],
     }
+
+
+def datastore_count_schema():
+    '''
+    Returns the schema for the datastore_count action.
+
+    :return: a dict
+    '''
+    return {
+        u'resource_ids': [ignore_missing, list_of_strings()],
+        u'version': [ignore_missing, int_validator]
+    }

--- a/ckanext/versioned_datastore/plugin.py
+++ b/ckanext/versioned_datastore/plugin.py
@@ -38,6 +38,7 @@ class VersionedSearchPlugin(SingletonPlugin):
             u'datastore_get_rounded_version': action.datastore_get_rounded_version,
             u'datastore_search_raw': action.datastore_search_raw,
             u'datastore_ensure_privacy': action.datastore_ensure_privacy,
+            u'datastore_count': action.datastore_count,
         }
 
     # IAuthFunctions
@@ -55,6 +56,7 @@ class VersionedSearchPlugin(SingletonPlugin):
             u'datastore_get_rounded_version': auth.datastore_get_rounded_version,
             u'datastore_search_raw': auth.datastore_search_raw,
             u'datastore_ensure_privacy': auth.datastore_ensure_privacy,
+            u'datastore_count': auth.datastore_count,
         }
 
     # ITemplateHelpers


### PR DESCRIPTION
This action allows counting the number of records, at a given version, in either all or a specific set of public resources.

Prompted by https://github.com/NaturalHistoryMuseum/data-portal/issues/360 but useful anyway.