### PR TITLE
Only write fields that exist

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/jsonl.py
+++ b/ckanext/versioned_datastore/lib/downloads/jsonl.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 
 import os
 
+from .utils import filter_data_fields
+
 
 @contextlib.contextmanager
 def jsonl_writer(request, target_dir, field_counts):
@@ -38,6 +40,9 @@ def jsonl_writer(request, target_dir, field_counts):
                 # lazily open the file for this resource id
                 resource_file_name = os.path.join(target_dir, u'{}.jsonl'.format(resource_id))
                 open_files[resource_id] = io.open(resource_file_name, u'w', encoding=u'utf-8')
+
+            if request.ignore_empty_fields:
+                data = filter_data_fields(data, field_counts[resource_id])
 
             if not request.separate_files:
                 # if the data is being written into one file we need to indicate which resource the

--- a/ckanext/versioned_datastore/lib/downloads/sv.py
+++ b/ckanext/versioned_datastore/lib/downloads/sv.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import os
 import unicodecsv
 
-from .utils import get_fields
+from .utils import get_fields, filter_data_fields
 
 
 def flatten_dict(data, path=None, separator=u' | '):
@@ -122,6 +122,9 @@ def sv_writer(request, target_dir, field_counts, dialect, extension):
                                                      u'{}.{}'.format(resource_id, extension))
                 open_files.append(open_file)
                 writers[resource_id] = writer
+
+            if request.ignore_empty_fields:
+                data = filter_data_fields(data, field_counts[resource_id])
 
             # the data dict may be nested, flatten it out first
             row = flatten_dict(data)


### PR DESCRIPTION
This may seem like a pointless exercise as surely if the field count is 0 for a field then it won't appear in any of the data dicts - however, because the data returned from elasticsearch is the source dict that was uploaded to it, it could contain nulls and empty string values. The calculate_field_counts function that generates the field counts does it by using exist queries and because these count indexed values it skips
nulls and empty strings which are ignored during indexing.

Fixes https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/issues/32