### PR TITLE
Send HTML download emails

### DIFF
--- a/ckanext/versioned_datastore/interfaces.py
+++ b/ckanext/versioned_datastore/interfaces.py
@@ -221,12 +221,24 @@ class IVersionedDatastoreQuerySchema(interfaces.Interface):
 
 class IVersionedDatastoreDownloads(interfaces.Interface):
 
-    def download_add_to_email_body(self, request):
+    def download_modify_email_templates(self, text_template: str, html_template: str):
         '''
-        Hook allowing other extensions to add extra text to the body of the email that is sent to
-        users on completion of a download.
+        Hook allowing other extensions to modify the templates used when sending download emails.
+        The templates can be modified in place or completely replaced.
+
+        :param text_template: the text email template string
+        :param html_template: the html email template string
+        :return: a 2-tuple containing the text template string and the html template string
+        '''
+        return text_template, html_template
+
+    def download_modify_email_template_context(self, request, context):
+        '''
+        Hook allowing other extensions to modify the templating context used to generate the
+        download email (both plain text and HTML versions) before it is sent.
 
         :param request: the DownloadRequest object
-        :return:
+        :param context: templating context dict
+        :return: context templating dict
         '''
-        return None
+        return context

--- a/ckanext/versioned_datastore/interfaces.py
+++ b/ckanext/versioned_datastore/interfaces.py
@@ -237,6 +237,10 @@ class IVersionedDatastoreDownloads(interfaces.Interface):
         Hook allowing other extensions to modify the templating context used to generate the
         download email (both plain text and HTML versions) before it is sent.
 
+        The default context contains:
+            - "download_url": the download zip's full URL
+            - "site_url": the CKAN site's full URL (this is taken straight from the config)
+
         :param request: the DownloadRequest object
         :param context: templating context dict
         :return: context templating dict

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock, patch, call, Mock
+
+import pytest
+from ckanext.versioned_datastore.lib.downloads.download import send_email
+
+site_url = 'https://data.nhm.ac.uk'
+
+
+class MockPlugin:
+
+    def __init__(self):
+        self.plain_template = 'plain {{ some_var }} template'
+        self.html_template = 'html {{ some_var }} template'
+        self.some_var = 'beans!'
+        self.rendered_plain_template = 'plain beans! template'
+        self.rendered_html_template = 'html beans! template'
+
+    def download_modify_email_templates(self, plain_template, html_template):
+        return self.plain_template, self.html_template
+
+    def download_modify_email_template_context(self, request, context):
+        context['some_var'] = self.some_var
+        return context
+
+
+@pytest.mark.ckan_config('ckan.site_url', site_url)
+@patch('ckanext.versioned_datastore.lib.downloads.download.mailer')
+class TestSendEmail:
+
+    def test_defaults(self, mock_mailer):
+        request = MagicMock(email_address='user@test.com')
+        zip_name = 'test.zip'
+
+        send_email(request, zip_name)
+
+        assert mock_mailer.mail_recipient.called
+        args, kwargs = mock_mailer.mail_recipient.call_args
+        assert kwargs['recipient_email'] == request.email_address
+        assert kwargs['recipient_name'] == 'Downloader'
+        assert kwargs['subject'] == 'Data download'
+        assert zip_name in kwargs['body']
+        assert zip_name in kwargs['body_html']
+        assert site_url in kwargs['body']
+        assert site_url in kwargs['body_html']
+
+    def test_overrides(self, mock_mailer):
+        request = MagicMock(email_address='user@test.com')
+        zip_name = 'test.zip'
+
+        mock_plugin = MockPlugin()
+        mock_plugin_implementations = MagicMock(return_value=[mock_plugin])
+        with patch('ckanext.versioned_datastore.lib.downloads.download.PluginImplementations',
+                   mock_plugin_implementations):
+            send_email(request, zip_name)
+
+        assert mock_mailer.mail_recipient.called
+        assert mock_mailer.mail_recipient.call_args == call(
+            recipient_email=request.email_address, recipient_name='Downloader',
+            subject='Data download', body=mock_plugin.rendered_plain_template,
+            body_html=mock_plugin.rendered_html_template
+        )
+
+    def test_default_context(self, mock_mailer):
+        request = MagicMock(email_address='user@test.com')
+        zip_name = 'test.zip'
+
+        mock_plugin = Mock(wraps=MockPlugin())
+        mock_plugin_implementations = MagicMock(return_value=[mock_plugin])
+        with patch('ckanext.versioned_datastore.lib.downloads.download.PluginImplementations',
+                   mock_plugin_implementations):
+            send_email(request, zip_name)
+
+        assert mock_mailer.mail_recipient.called
+        assert mock_plugin.download_modify_email_template_context.called
+        args, kwargs = mock_plugin.download_modify_email_template_context.call_args
+        req, ctx = args
+        assert req == request
+        # defaults
+        assert 'site_url' in ctx
+        assert 'download_url' in ctx
+        # our extra one
+        assert 'some_var' in ctx


### PR DESCRIPTION
On the NHM's Office365 email client we have some URL safety checking service that alters the URLs in emails to put them through a safety filter. This mangles the emails something chronic and they end up looking something like this:

![image](https://user-images.githubusercontent.com/4718259/110565124-e040c600-8145-11eb-8310-98a38b1db63e.png)

This PR fixes that by sending HTML emails for downloads from the versioned datastore plugin. This results in emails that look like this instead:

![image](https://user-images.githubusercontent.com/4718259/110565214-00708500-8146-11eb-935d-5fc782163ada.png)

Much nicer!

This change has a breaking interface change in it and therefore will require a new major version when tagged for release.