### PR TITLE
DwC-A downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ Name|Description|Example
 `ckanext.versioned_datastore.redis_port`|The port to use to connect to the redis host|`6379`
 `ckanext.versioned_datastore.redis_database`|The redis database index to use to store datastore multisearch slugs in|`1`
 `ckanext.versioned_datastore.slug_ttl`|The amount of time slugs should last for, in days. Default: `7`|`7`
+`ckanext.versioned_datastore.dwc_core_extension_name`|The name of the DwC core extension to use, as defined in [dwc/writer.py](/ckanext/versioned_datastore/lib/downloads/dwc/writer.py).|`gbif_occurrence`
+`ckanext.versioned_datastore.dwc_extension_names`|A comma-separated list of (non-core) DwC extension names, as defined in [dwc/writer.py](/ckanext/versioned_datastore/lib/downloads/dwc/writer.py).|`gbif_multimedia`
+`ckanext.versioned_datastore.dwc_org_name`|The organisation name to use in DwC-A metadata. Default: the value of `ckanext.doi.publisher` or `ckan.site_title`|`The Natural History Museum`
+`ckanext.versioned_datastore.dwc_org_email`|The contact email to use in DwC-A metadata. Default: the value of `smtp.mail_from`|`contact@yoursite.com`
+`ckanext.versioned_datastore.dwc_default_license`|The license to use in DwC-A metadata if the resources have differing licenses or no license is specified. Default: `null`|`http://creativecommons.org/publicdomain/zero/1.0/legalcode`
 
 
 # Further Setup

--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -21,6 +21,7 @@ from jinja2 import Template
 
 from .jsonl import jsonl_writer
 from .sv import sv_writer
+from .dwc import dwc_writer
 from .utils import calculate_field_counts
 from .. import common
 from ..datastore_utils import trim_index_name, prefix_resource
@@ -32,6 +33,7 @@ format_registry = {
     'csv': functools.partial(sv_writer, dialect='excel', extension='csv'),
     'tsv': functools.partial(sv_writer, dialect='excel-tab', extension='tsv'),
     'jsonl': jsonl_writer,
+    'dwc': dwc_writer
 }
 
 default_body = '''

--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -151,6 +151,9 @@ def download(request):
     :param request: the DownloadRequest object, see that for parameter details
     '''
     download_dir = toolkit.config.get('ckanext.versioned_datastore.download_dir')
+    # make sure this download dir exists
+    if not os.path.exists(download_dir):
+        os.mkdir(download_dir)
     download_hash = request.generate_download_hash()
     existing_file = next(iglob(os.path.join(download_dir, f'*_{download_hash}.zip')), None)
     if existing_file is not None:

--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -77,7 +77,7 @@ def ensure_download_queue_exists():
 
 
 def queue_download(email_address, download_id, query_hash, query, query_version, search,
-                   resource_ids_and_versions, separate_files, file_format, ignore_empty_fields):
+                   resource_ids_and_versions, separate_files, file_format, format_args, ignore_empty_fields):
     '''
     Queues a job which when run will download the data for the resource.
 
@@ -85,7 +85,7 @@ def queue_download(email_address, download_id, query_hash, query, query_version,
     '''
     ensure_download_queue_exists()
     request = DownloadRequest(email_address, download_id, query_hash, query, query_version, search,
-                              resource_ids_and_versions, separate_files, file_format,
+                              resource_ids_and_versions, separate_files, file_format, format_args,
                               ignore_empty_fields)
     return toolkit.enqueue_job(download, args=[request], queue='download', title=str(request))
 
@@ -99,7 +99,7 @@ class DownloadRequest(object):
     '''
 
     def __init__(self, email_address, download_id, query_hash, query, query_version, search,
-                 resource_ids_and_versions, separate_files, file_format, ignore_empty_fields):
+                 resource_ids_and_versions, separate_files, file_format, format_args, ignore_empty_fields):
         self.email_address = email_address
         self.download_id = download_id
         self.query_hash = query_hash
@@ -109,6 +109,7 @@ class DownloadRequest(object):
         self.resource_ids_and_versions = resource_ids_and_versions
         self.separate_files = separate_files
         self.file_format = file_format
+        self.format_args = format_args
         self.ignore_empty_fields = ignore_empty_fields
 
     @property
@@ -134,6 +135,7 @@ class DownloadRequest(object):
             sorted(self.resource_ids_and_versions.items()),
             self.separate_files,
             self.file_format,
+            self.format_args,
             self.ignore_empty_fields,
         ]
         download_hash = hashlib.sha1('|'.join(map(str, to_hash)).encode('utf-8'))
@@ -186,6 +188,7 @@ def download(request):
             'resources': {},
             'separate_files': request.separate_files,
             'file_format': request.file_format,
+            'format_args': request.format_args,
             'ignore_empty_fields': request.ignore_empty_fields,
         }
         # calculate, per resource, the number of values for each field present in the search

--- a/ckanext/versioned_datastore/lib/downloads/dwc/__init__.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/__init__.py
@@ -1,0 +1,1 @@
+from .writer import dwc_writer

--- a/ckanext/versioned_datastore/lib/downloads/dwc/archive.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/archive.py
@@ -317,7 +317,7 @@ class Archive(object):
                         toolkit.h.create_multisearch_citation_text(query_doi, html=False),
                         {'identifier': f'https://doi.org/{query_doi.doi}'})
 
-        if self.schema.core_extension and 'gbif' in self.schema.core_extension.location:
+        if self.schema.core_extension and self.schema.core_extension.location.base == GBIFUrls.base_url:
             dataset_metadata['keywordSet'].append({
                 'keyword': self.schema.row_type_name,
                 'keywordThesaurus': f'GBIF Dataset Type Vocabulary: {GBIFUrls.thesaurus}'

--- a/ckanext/versioned_datastore/lib/downloads/dwc/archive.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/archive.py
@@ -78,9 +78,9 @@ class Archive(object):
         root_field_names = set([f.split('.')[0] for f in field_names])
         all_ext_field_names = [item for sublist in extension_map.values() for item in sublist]
 
-        standard_fields = ['_id', 'datasetID', 'basisOfRecord', 'dynamicProperties']
-        core_field_names = standard_fields + [f for f in root_field_names if
-                                              f not in all_ext_field_names and f in self.schema.props]
+        standard_fields = ['datasetID', 'basisOfRecord', 'dynamicProperties']
+        dataset_fields = [f for f in root_field_names if f not in all_ext_field_names and f in self.schema.props]
+        core_field_names = ['_id'] + list(set(standard_fields + dataset_fields))
         self._core_file = open(os.path.join(self._build_dir, self._core_file_name), 'w')
         self._core_writer = csv.DictWriter(self._core_file, core_field_names, dialect='unix')
 
@@ -91,8 +91,7 @@ class Archive(object):
             subfields = [f.split('.')[-1] for f in field_names if
                          f.split('.')[0] in extension_map_matches]
             potential_fields = self.schema.extension_props[e.name]
-            ext_field_names = ['_id'] + list(
-                set([f for f in subfields if f in potential_fields]))
+            ext_field_names = ['_id'] + list(set([f for f in subfields if f in potential_fields]))
             open_file = open(os.path.join(self._build_dir, f'{e.name.lower()}.csv'), 'w')
             self._ext_files[e.name] = open_file
             writer = csv.DictWriter(open_file, ext_field_names, dialect='unix')

--- a/ckanext/versioned_datastore/lib/downloads/dwc/archive.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/archive.py
@@ -295,7 +295,7 @@ class Archive(object):
             package = packages[0]
             dataset_metadata['title'] = resource['name']
             dataset_metadata['alternateIdentifier'] += self.request.resource_ids
-            dataset_metadata['pubDate'] = package.get('doi_date_published', resource.get('created'))
+            dataset_metadata['pubDate'] = package.get('metadata_modified', resource.get('created'))
             dataset_metadata['abstract'] = {'para': resource.get('description')}
             dataset_metadata['distribution'][0]['online']['url'] = (
                 site_url + toolkit.url_for('resource.read', id=package['id'],

--- a/ckanext/versioned_datastore/lib/downloads/dwc/archive.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/archive.py
@@ -1,0 +1,318 @@
+import csv
+import os
+import shutil
+from collections import OrderedDict
+from datetime import datetime as dt
+
+from ckan.plugins import plugin_loaded, toolkit
+from lxml import etree
+
+from .schema import Schema
+from .urls import TDWGUrls, XMLUrls, GBIFUrls
+from .utils import NSMap, json_to_xml, get_setting
+
+
+class Archive(object):
+    def __init__(self, schema: Schema, request, target_dir, sub_dir=None):
+        self.schema = schema
+        self.dir = target_dir
+        self.request = request
+        self.sub_dir = sub_dir
+        self._core_file = None
+        self._core_writer = None
+        self._ext_files = None
+        self._ext_writers = None
+        self._extension_map = {}
+        self.rows_written = 0
+
+    @property
+    def _uid(self):
+        if self.single_resource:
+            return self.request.resource_ids[0]
+        elif self.request.separate_files:
+            return self.sub_dir
+        else:
+            return self.request.query_hash
+
+    @property
+    def _build_dir(self):
+        return os.path.join(self.dir, self._uid)
+
+    @property
+    def _core_file_name(self):
+        return f'{self.schema.row_type_name.lower()}.csv'
+
+    @property
+    def single_resource(self):
+        return len(self.request.resource_ids) == 1 and self.request.query == {}
+
+    def open(self, field_names, extension_map):
+        self._extension_map = extension_map
+        os.mkdir(self._build_dir)
+        root_field_names = set([f.split('.')[0] for f in field_names])
+        all_ext_field_names = [item for sublist in extension_map.values() for item in sublist]
+
+        core_field_names = ['_id', 'datasetID', 'basisOfRecord'] + [f for f in root_field_names if
+                                                                    f not in all_ext_field_names and f in self.schema.props]
+        self._core_file = open(os.path.join(self._build_dir, self._core_file_name), 'w')
+        self._core_writer = csv.DictWriter(self._core_file, core_field_names, dialect='unix')
+
+        self._ext_files = {}
+        self._ext_writers = {}
+        for e in self.schema.extensions:
+            extension_map_matches = [k for k, v in extension_map.items() if v == e.name]
+            subfields = [f.split('.')[-1] for f in field_names if
+                         f.split('.')[0] in extension_map_matches]
+            potential_fields = self.schema.extension_props[e.name]
+            ext_field_names = ['_id'] + list(set([f for f in subfields if f in potential_fields]))
+            open_file = open(os.path.join(self._build_dir, f'{e.name.lower()}.csv'), 'w')
+            self._ext_files[e.name] = open_file
+            writer = csv.DictWriter(open_file, ext_field_names, dialect='unix')
+            self._ext_writers[e.name] = writer
+        return self
+
+    def close(self):
+        if self._core_file is None:
+            # this might be called several times due to the defaultdict implementation in writer.py
+            return
+        self._core_file.close()
+        for f in self._ext_files.values():
+            f.close()
+        with open(os.path.join(self._build_dir, 'meta.xml'), 'w') as f:
+            meta_content = self.make_meta()
+            f.write(meta_content)
+        with open(os.path.join(self._build_dir, 'eml.xml'), 'w') as f:
+            eml_content = self.make_eml()
+            f.write(eml_content)
+        shutil.make_archive(os.path.join(self.dir, self.sub_dir or 'dwca'), 'zip', self._build_dir)
+        shutil.rmtree(self._build_dir)
+        self._core_file = None
+        self._core_writer = None
+        self._ext_files = None
+        self._ext_writers = None
+        self._extension_map = {}
+
+    def initialise(self, data):
+        '''
+        Only runs for the first row in the dataset. Checks that certain fields are the correct data
+        type before writing the headers.
+        :param data:
+        :return:
+        '''
+        if self.rows_written > 0:
+            return
+        # check 'type' is right
+        valid_types = ['StillImage', 'MovingImage', 'Sound', 'PhysicalObject', 'Event', 'Text']
+        if 'type' in data and data['type'] not in valid_types:
+            self._core_writer.fieldnames = [f for f in self._core_writer.fieldnames if f != 'type']
+        self._core_writer.writeheader()
+        for writer in self._ext_writers.values():
+            writer.writeheader()
+
+    def _extract_record(self, record, id_field):
+        core = {}
+        ext = {}
+
+        if id_field not in record:
+            raise Exception(f'Record does not have ID field {id_field}')
+        record_id = record.get(id_field)
+        core['_id'] = record_id
+
+        for k, v in record.items():
+            if k in self._extension_map:
+                ext_props = self._ext_writers[self._extension_map[k]].fieldnames
+
+                def _extract_ext(subdict):
+                    props = {ek: ev for ek, ev in subdict.items() if ek in ext_props}
+                    props['_id'] = record_id
+                    return props
+
+                if isinstance(v, list):
+                    ext_extracted = [_extract_ext(x) for x in v]
+                elif isinstance(v, dict):
+                    ext_extracted = [_extract_ext(v)]
+                else:
+                    ext_extracted = [{k: v, '_id': record_id}]
+                ext[self._extension_map[k]] = ext_extracted
+            else:
+                if k in self._core_writer.fieldnames:
+                    core[k] = v
+        return core, ext
+
+    def write_record(self, record, id_field='_id'):
+        if self._core_file is None:
+            # if this is None, the file is not open, and this is being called from the wrong place.
+            raise Exception('File is not open.')
+        core_row, ext_rows = self._extract_record(record, id_field)
+        self._core_writer.writerow(core_row)
+        self.rows_written += 1
+        for e, rows in ext_rows.items():
+            for row in rows:
+                self._ext_writers[e].writerow(row)
+
+    def make_meta(self):
+        nsmap = NSMap(xsi=XMLUrls.xsi,
+                      xs=XMLUrls.xs)
+        root = etree.Element('archive', nsmap=nsmap,
+                             attrib={'xmlns': TDWGUrls.xmlns, 'metadata': 'eml.xml',
+                                     nsmap.ns('xsi', 'schemaLocation'): ' '.join(
+                                         [TDWGUrls.xmlns, TDWGUrls.metadata])})
+        attributes = {'encoding': 'UTF-8',
+                      'linesTerminatedBy': '\n',
+                      'fieldsTerminatedBy': ',',
+                      'fieldsEnclosedBy': '"',
+                      'ignoreHeaderLines': '1'}
+        core = etree.SubElement(root, 'core', rowType=self.schema.row_type, **attributes)
+        core_files = etree.SubElement(core, 'files')
+        core_files_location = etree.SubElement(core_files, 'location')
+        core_files_location.text = self._core_file_name
+        etree.SubElement(core, 'id', index='0')
+        for i, c in enumerate(self._core_writer.fieldnames):
+            if c == '_id':
+                continue
+            etree.SubElement(core, 'field', index=str(i), term=self.schema.props.get(c).iri)
+        for e in self.schema.extensions:
+            ext_root = etree.SubElement(root, 'extension', rowType=e.row_type, **attributes)
+            ext_files = etree.SubElement(ext_root, 'files')
+            ext_files_location = etree.SubElement(ext_files, 'location')
+            ext_files_location.text = f'{e.name.lower()}.csv'
+            etree.SubElement(ext_root, 'coreid', index='0')
+            ext_props = self.schema.extension_props[e.name]
+            for i, c in enumerate(self._ext_writers[e.name].fieldnames):
+                if c == '_id':
+                    continue
+                etree.SubElement(ext_root, 'field', index=str(i), term=ext_props.get(c).iri)
+        return etree.tostring(root, pretty_print=True).decode()
+
+    def make_eml(self):
+        # load some useful actions so we don't have to fetch them repeatedly
+        resource_show = toolkit.get_action('resource_show')
+        package_show = toolkit.get_action('package_show')
+
+        # get the resources and packages associated with the request
+        resources = [resource_show({}, {'id': r}) for r in self.request.resource_ids]
+        packages = [package_show({}, {'id': r['package_id']}) for r in resources]
+
+        # define some variables
+        org = {'organizationName': get_setting('ckanext.versioned_datastore.dwc_org_name',
+                                               'ckanext.doi.publisher', 'ckan.site_title'),
+               'electronicMailAddress': get_setting(
+                   'ckanext.versioned_datastore.dwc_org_email', 'smtp.mail_from'),
+               'onlineUrl': get_setting('ckan.site_url')}
+        site_name = get_setting('ckanext.doi.site_title', 'ckan.site_title')
+        site_url = get_setting('ckan.site_url', default='')
+        licenses = list(set([p.get('license_title') for p in packages if
+                             p.get('license_title') is not None]))
+        query_license = licenses[0] if len(licenses) == 1 else get_setting(
+            'ckanext.versioned_datastore.dwc_default_license', default='null')
+
+        # set up the metadata dict in order (otherwise GBIF complains) with some defaults
+        dataset_metadata = OrderedDict({
+            'alternateIdentifier': [
+                self.request.query_hash
+            ],
+            'title': f'Query on {site_name}',
+            'creator': [org],
+            'metadataProvider': [org],
+            'pubDate': dt.now().strftime('%Y-%m-%d'),
+            'language': get_setting('ckan.locale_default'),
+            'abstract': {
+                'para': f'Query ID {self.request.query_hash} on {site_name} ({self.rows_written} records).'},
+            'keywordSet': [],
+            'intellectualRights': {'para': query_license},
+            'distribution': ({'online': {'url': site_url}}, {'scope': 'document'}),
+            'contact': [org]
+        })
+        additional_metadata = {
+            'metadata': {
+                'gbif': {
+                    'dateStamp': dt.now().strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'citation': None,
+                    'resourceLogoUrl': site_url + toolkit.config.get('ckan.site_logo', '')
+                }}}
+
+        if self.single_resource:
+            # if it's just downloading one resource with no filters
+            resource = resources[0]
+            package = packages[0]
+            dataset_metadata['title'] = resource['name']
+            dataset_metadata['alternateIdentifier'] += self.request.resource_ids
+            dataset_metadata['pubDate'] = package.get('doi_date_published', resource.get('created'))
+            dataset_metadata['abstract'] = {'para': resource.get('description')}
+            dataset_metadata['distribution'][0]['online']['url'] = (
+                site_url + toolkit.url_for('resource.read', id=package['id'],
+                                           resource_id=resource['id']), {'function': 'information'})
+            if 'doi' in package:
+                dataset_metadata['alternateIdentifier'].append('doi:' + package['doi'])
+                pkg_year = toolkit.h.package_get_year(package)
+                pkg_title = package['title']
+                pkg_doi = package['doi']
+                pkg_author = package['author']
+                site_title = toolkit.h.get_site_title()
+                additional_metadata['metadata']['gbif']['citation'] = (
+                    f'{pkg_author} ({pkg_year}). Dataset: {pkg_title}. {site_title}',
+                    {'identifier': f'https://doi.org/{pkg_doi}'})
+        else:
+            if plugin_loaded('query_dois'):
+                from ckanext.query_dois.lib.doi import find_existing_doi
+                query_doi = find_existing_doi(self.request.resource_ids_and_versions,
+                                              self.request.query_hash, self.request.query_version)
+                if query_doi:
+                    dataset_metadata['alternateIdentifier'] += ['doi:' + query_doi.doi]
+                    dataset_metadata['distribution'][0]['online']['url'] = (
+                        site_url + toolkit.url_for('query_doi.landing_page',
+                                                   data_centre=get_setting('ckanext.query_dois.prefix'),
+                                                   identifier=query_doi.doi), {
+                            'function': 'information'})
+                    additional_metadata['metadata']['gbif']['citation'] = (
+                        toolkit.h.create_multisearch_citation_text(query_doi, html=False),
+                        {'identifier': f'https://doi.org/{query_doi.doi}'})
+
+        if self.schema.core_extension and 'gbif' in self.schema.core_extension.location:
+            dataset_metadata['keywordSet'].append({
+                'keyword': self.schema.row_type_name,
+                'keywordThesaurus': f'GBIF Dataset Type Vocabulary: {GBIFUrls.thesaurus}'
+            })
+
+        if plugin_loaded('attribution'):
+            package_contributions_show = toolkit.get_action('package_contributions_show')
+            authors = []
+            for r in resources:
+                contributions = package_contributions_show({}, {'id': r['package_id']})
+                for c in contributions['contributions']:
+                    if c['agent']['id'] in authors:
+                        continue
+                    agent = {}
+                    if c['agent']['external_id']:
+                        agent['userId'] = (
+                            c['agent']['external_id'], {'directory': c['agent']['external_id_url']})
+                    if c['agent']['agent_type'] == 'person':
+                        agent['individualName'] = {'givenName': c['agent']['given_names'],
+                                                   'surName': c['agent']['family_name']}
+                    else:
+                        agent['organizationName'] = c['agent']['name']
+                    dataset_metadata['creator'].append(agent)
+                    authors.append(c['agent']['id'])
+
+        nsmap = NSMap(eml=XMLUrls.eml,
+                      dc=XMLUrls.dc,
+                      xsi=XMLUrls.xsi,
+                      xml=XMLUrls.xml)
+
+        root = etree.Element(nsmap.ns('eml', 'eml'),
+                             nsmap=nsmap,
+                             attrib={'scope': 'system',
+                                     'system': 'http://gbif.org',
+                                     nsmap.ns('xsi', 'schemaLocation'): ' '.join(
+                                         [XMLUrls.eml, GBIFUrls.eml]),
+                                     'packageId': self._uid,
+                                     nsmap.ns('xml', 'lang'): 'en'})
+
+        for i in json_to_xml('dataset', dataset_metadata):
+            root.append(i)
+
+        if additional_metadata['metadata']['gbif'].get('citation') is not None:
+            for i in json_to_xml('additionalMetadata', additional_metadata):
+                root.append(i)
+
+        return etree.tostring(root, pretty_print=True).decode()

--- a/ckanext/versioned_datastore/lib/downloads/dwc/schema.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/schema.py
@@ -4,7 +4,7 @@ import os
 import pandas as pd
 
 from .schema_parts import Domain, Extension, Prop, PropCollection
-from .urls import TDWGUrls
+from .urls import TDWGUrls, SchemaUrl
 from .utils import load_schema
 
 
@@ -51,7 +51,7 @@ class Schema(object):
 
         if core_extension_url is not None:
             temp_props = {}
-            extension_schema = load_schema(core_extension_url)
+            extension_schema = load_schema(core_extension_url.url, core_extension_url.base)
             ce_props = extension_schema.findall('.//{*}property')
             for p in ce_props:
                 domain_name = p.attrib['group']
@@ -72,7 +72,7 @@ class Schema(object):
         extensions = []
         extension_props = {}
         for e in extension_urls:
-            extension_schema = load_schema(e)
+            extension_schema = load_schema(e.url, e.base)
             ext = Extension.create(e, extension_schema)
             extensions.append(ext)
             schema_props = extension_schema.findall('.//{*}property')

--- a/ckanext/versioned_datastore/lib/downloads/dwc/schema.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/schema.py
@@ -1,0 +1,125 @@
+import json
+import os
+
+import pandas as pd
+
+from .schema_parts import Domain, Extension, Prop, PropCollection
+from .urls import TDWGUrls
+from .utils import load_schema
+
+
+class Schema(object):
+    def __init__(self, domains, props, core_extension=None, extensions=None, extension_props=None,
+                 row_type='http://rs.tdwg.org/dwc/terms/Occurrence'):
+        self.domains = domains
+        self.props = props
+        self.core_extension = core_extension
+        self.extensions = extensions or []
+        self.extension_props = extension_props or PropCollection([])
+        self.row_type = core_extension.row_type if core_extension else row_type
+        self.row_type_name = core_extension.name if core_extension else row_type.split('/')[-1]
+
+    @classmethod
+    def regenerate(cls, core_extension_url=None, extension_urls=None):
+        extension_urls = extension_urls or []
+
+        df = pd.read_csv(TDWGUrls.terms_csv)
+        # ignore deprecated terms
+        df = df[df.status == 'recommended']
+        # drop some columns we don't need
+        df = df.drop(['issued', 'status', 'replaces'], axis=1)
+
+        domains_df = df[df.rdf_type == 'http://www.w3.org/2000/01/rdf-schema#Class']
+        domains_df = domains_df.drop(['organized_in', 'rdf_type'], axis=1)
+        domains = [Domain.create(d) for _, d in domains_df.iterrows()]
+
+        props_df = df[df.rdf_type == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#Property']
+        props_df = props_df.drop(['rdf_type'], axis=1)
+
+        # supplementary property information is in the core schema
+        core_xsd = load_schema(TDWGUrls.core, base_url=TDWGUrls.base_url)
+        core_props = {}
+        for _, p in props_df.iterrows():
+            xml_element = core_xsd.find(f'.//{{*}}element[@name="{p.term_localName}"]')
+            # (hopefully) temporary fix for https://github.com/tdwg/dwc/issues/403
+            if xml_element is None and p.term_localName == 'degreeOfEstablishment':
+                xml_element = core_xsd.find('.//{*}element[@name="degreeOfEstablishmentMeans"]')
+            elif xml_element is None and p.term_localName == 'waterBody':
+                xml_element = core_xsd.find('.//{*}element[@name="waterbody"]')
+            prop = Prop.create(p, xml_element, flags=[p['flags']])
+            core_props[prop.name] = prop
+
+        if core_extension_url is not None:
+            temp_props = {}
+            extension_schema = load_schema(core_extension_url)
+            ce_props = extension_schema.findall('.//{*}property')
+            for p in ce_props:
+                domain_name = p.attrib['group']
+                prop_name = p.attrib['name']
+                prop = core_props.get(prop_name)
+                if prop is not None:
+                    prop.update(xml_element_source=p)
+                else:
+                    prop = Prop.create(xml_element_source=p, flags=['core_extension'])
+                temp_props[prop.name] = prop
+            core_props = temp_props
+            ce = Extension.create(core_extension_url, extension_schema, core=True)
+        else:
+            ce = None
+
+        props = PropCollection(core_props.values())
+
+        extensions = []
+        extension_props = {}
+        for e in extension_urls:
+            extension_schema = load_schema(e)
+            ext = Extension.create(e, extension_schema)
+            extensions.append(ext)
+            schema_props = extension_schema.findall('.//{*}property')
+            extension_props[ext.name] = PropCollection(
+                [Prop.create(xml_element_source=p, extension=ext.name) for p in schema_props])
+
+        return cls(domains, props, ce, extensions, extension_props)
+
+    def serialise(self):
+        serialised_dict = {
+            'domains': [d.serialise() for d in self.domains],
+            'props': self.props.serialise(),
+            'row_type': self.row_type
+        }
+        if self.core_extension is not None:
+            serialised_dict['core_extension'] = self.core_extension.serialise()
+        if len(self.extensions) > 0:
+            serialised_dict['extensions'] = [e.serialise() for e in self.extensions]
+            serialised_dict['extension_props'] = {k: v.serialise() for k, v in
+                                                  self.extension_props.items()}
+        return serialised_dict
+
+    def save(self, cache_path):
+        with open(cache_path, 'w') as f:
+            json.dump(self.serialise(), f, indent=2)
+
+    @classmethod
+    def load(cls, cache_path=None, **kwargs):
+        if cache_path is None:
+            return cls.regenerate(**kwargs)
+        if os.path.exists(cache_path):
+            with open(cache_path, 'r') as f:
+                content = json.load(f)
+            init_dict = {
+                'domains': [Domain.load(d) for d in content['domains']],
+                'props': PropCollection.load(content['props']),
+                'extensions': [Extension.load(e) for e in content.get('extensions', [])],
+                'extension_props': {k: PropCollection.load(v) for k, v in
+                                    content.get('extension_props', {}).items()},
+                'row_type': content.get('row_type', 'http://rs.tdwg.org/dwc/terms/Occurrence')
+            }
+            ce = content.get('core_extension')
+            if ce is not None:
+                init_dict['core_extension'] = Extension.load(ce)
+                init_dict['row_type'] = init_dict['core_extension'].row_type
+            return cls(**init_dict)
+        else:
+            new_archiver = cls.regenerate(**kwargs)
+            new_archiver.save(cache_path)
+            return new_archiver

--- a/ckanext/versioned_datastore/lib/downloads/dwc/schema_parts.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/schema_parts.py
@@ -1,0 +1,173 @@
+from .utils import load_schema
+
+
+class Extension(object):
+    def __init__(self, location, prop_names, row_type, name, core=False):
+        self.location = location
+        self.prop_names = prop_names or []
+        self.row_type = row_type
+        self.name = name
+        self.core = core
+
+    @classmethod
+    def create(cls, url, extension_schema=None, core=False):
+        if extension_schema is None:
+            extension_schema = load_schema(url)
+        row_type = extension_schema.attrib['rowType']
+        name = extension_schema.attrib['name']
+        schema_props = extension_schema.findall('.//{*}property')
+        prop_names = [p.attrib['name'] for p in schema_props]
+        return cls(url, prop_names, row_type, name, core)
+
+    @classmethod
+    def load(cls, serialised):
+        return cls(**serialised)
+
+    def serialise(self):
+        return {
+            'location': self.location,
+            'prop_names': self.prop_names,
+            'row_type': self.row_type,
+            'name': self.name,
+            'core': self.core
+        }
+
+
+class Prop(object):
+    def __init__(self, **kwargs):
+        # preferable to instantiate with .create() class method instead
+        self.name = kwargs.get('name')
+        self.iri = kwargs.get('iri')
+        self.prop_type = kwargs.get('prop_type', str)
+        self.is_identifier = kwargs.get('is_identifier', False)
+        self.domain = kwargs.get('domain')
+        self.vocabulary = kwargs.get('vocabulary', [])
+        self._flags = kwargs.get('flags', [])
+        self.extension = kwargs.get('extension')
+
+    @classmethod
+    def create(cls, row_source=None, xml_element_source=None, flags=None, extension=None):
+        flags = flags or []
+        new_prop = cls()
+        new_prop.update(row_source, xml_element_source, flags, extension)
+        return new_prop
+
+    def update(self, row_source=None, xml_element_source=None, flags=None, extension=None):
+        flags = flags or []
+        if row_source is None and xml_element_source is None:
+            raise Exception('At least one source required.')
+        if row_source is not None:
+            self.name = row_source.term_localName
+            self.iri = row_source.term_iri
+            self.domain = row_source.organized_in
+        else:
+            self.name = xml_element_source.attrib['name']
+            self.iri = xml_element_source.attrib.get('qualName')
+            self.domain = xml_element_source.attrib.get('group')
+        if xml_element_source is None:
+            self.is_identifier = False
+            thesaurus_url = None
+        else:
+            self.is_identifier = xml_element_source.attrib.get('substitutionGroup') == 'dwc:anyIdentifier'
+            prop_type = xml_element_source.attrib.get('type')
+            if prop_type != 'xs:string':
+                self.prop_type = prop_type
+            thesaurus_url = xml_element_source.attrib.get('thesaurus')
+        if thesaurus_url is not None:
+            thesaurus = load_schema(thesaurus_url)
+            terms = thesaurus.findall('.//{*}concept')
+            identifier_key = next(k for k in terms[0].attrib.keys() if 'identifier' in k)
+            self.vocabulary = [t.attrib[identifier_key] for t in terms]
+        else:
+            self.vocabulary = []
+        self._flags = [f.lower() for f in set(self._flags + flags) if isinstance(f, str)]
+        self.extension = extension
+
+    @property
+    def flags(self):
+        return [f.lower() for f in self._flags]
+
+    @property
+    def core(self):
+        return self.extension is None
+
+    def serialise(self):
+        return {
+            'name': self.name,
+            'iri': self.iri,
+            'is_identifier': self.is_identifier,
+            'domain': self.domain,
+            'vocabulary': self.vocabulary,
+            'flags': self.flags
+        }
+
+    @classmethod
+    def load(cls, serialised):
+        return cls(**serialised)
+
+    def __repr__(self):
+        if self.vocabulary:
+            return f'{self.name} ({len(self.vocabulary)} terms)'
+        else:
+            return self.name
+
+    def has_flags(self, *flags):
+        return all([f.lower() in self.flags for f in flags])
+
+
+class PropCollection(dict):
+    def __init__(self, props):
+        if not isinstance(props, dict):
+            try:
+                props = {p.name: p for p in props}
+            except:
+                raise TypeError('Must be dict or iterable.')
+        super(PropCollection, self).__init__(**props)
+
+    def flagged(self, *flags):
+        return PropCollection([v for v in self.values() if v.has_flags(*flags)])
+
+    def serialise(self):
+        return {k: v.serialise() for k, v in self.items()}
+
+    @classmethod
+    def load(cls, serialised):
+        if isinstance(serialised, list):
+            serialised = [Prop.load(s) for s in serialised]
+        elif isinstance(serialised, dict):
+            serialised = {k: Prop.load(v) for k, v in serialised.items()}
+        return cls(serialised)
+
+
+class Domain(object):
+    def __init__(self, name, label, iri):
+        self.name = name
+        self.label = label
+        self.iri = iri
+
+    def props(self, schema):
+        if schema is None:
+            return []
+        return [p for p in schema.props if p.domain == self.iri]
+
+    def identifier(self, schema):
+        return next(p for p in self.props(schema) if p.is_identifier)
+
+    @classmethod
+    def create(cls, source):
+        name = source.term_localName
+        label = source.label
+        iri = source.term_iri
+        return cls(name, label, iri)
+
+    def serialise(self):
+        return {'name': self.name,
+                'label': self.label,
+                'iri': self.iri}
+
+    @classmethod
+    def load(cls, serialised):
+        return cls(**serialised)
+
+    def __repr__(self):
+        return self.name

--- a/ckanext/versioned_datastore/lib/downloads/dwc/urls.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/urls.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 class SchemaUrl:
     url: str
     base: str
+    fields: list = None
 
 
 class TDWGUrls:
@@ -42,5 +43,5 @@ core_extensions = {
 
 extensions = {
     'gbif_multimedia': SchemaUrl('https://rs.gbif.org/extension/gbif/1.0/multimedia.xml',
-                                 GBIFUrls.base_url)
+                                 GBIFUrls.base_url, ['associatedMedia'])
 }

--- a/ckanext/versioned_datastore/lib/downloads/dwc/urls.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/urls.py
@@ -2,6 +2,11 @@ from dataclasses import dataclass
 
 
 @dataclass
+class SchemaUrl:
+    url: str
+    base: str
+
+
 class TDWGUrls:
     base_url = 'https://dwc.tdwg.org/xml'
     xmlns = 'http://rs.tdwg.org/dwc/text'
@@ -14,25 +19,28 @@ class TDWGUrls:
     metadata = 'http://rs.tdwg.org/dwc/text/tdwg_dwc_text.xsd'
 
 
-@dataclass
 class GBIFUrls:
     base_url = 'https://rs.gbif.org'
-    core_extensions = {
-        'occurrence': 'https://rs.gbif.org/core/dwc_occurrence_2020-07-15.xml',
-        'taxon': 'https://rs.gbif.org/core/dwc_taxon_2015-04-24.xml',
-        'event': 'https://rs.gbif.org/core/dwc_event_2016_06_21.xml'
-    }
-    extensions = {
-        'multimedia': 'https://rs.gbif.org/extension/gbif/1.0/multimedia.xml'
-    }
     eml = 'http://rs.gbif.org/schema/eml-gbif-profile/1.1/eml.xsd'
     thesaurus = 'http://rs.gbif.org/vocabulary/gbif/dataset_type.xml'
 
 
-@dataclass
 class XMLUrls:
     xsi = 'http://www.w3.org/2001/XMLSchema-instance'
     xs = 'http://www.w3.org/2001/XMLSchema'
     xml = 'http://www.w3.org/XML/1998/namespace'
     dc = 'http://purl.org/dc/terms'
     eml = 'eml://ecoinformatics.org/eml-2.1.1'
+
+
+core_extensions = {
+    'gbif_occurrence': SchemaUrl('https://rs.gbif.org/core/dwc_occurrence_2020-07-15.xml',
+                                 GBIFUrls.base_url),
+    'gbif_taxon': SchemaUrl('https://rs.gbif.org/core/dwc_taxon_2015-04-24.xml', GBIFUrls.base_url),
+    'gbif_event': SchemaUrl('https://rs.gbif.org/core/dwc_event_2016_06_21.xml', GBIFUrls.base_url)
+}
+
+extensions = {
+    'gbif_multimedia': SchemaUrl('https://rs.gbif.org/extension/gbif/1.0/multimedia.xml',
+                                 GBIFUrls.base_url)
+}

--- a/ckanext/versioned_datastore/lib/downloads/dwc/urls.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/urls.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class TDWGUrls:
+    base_url = 'https://dwc.tdwg.org/xml'
+    xmlns = 'http://rs.tdwg.org/dwc/text'
+    core = 'https://dwc.tdwg.org/xml/tdwg_dwcterms.xsd'
+    base_types = 'https://dwc.tdwg.org/xml/tdwg_basetypes.xsd'
+    core_classes = 'https://dwc.tdwg.org/xml/tdwg_dwc_classes.xsd'
+    core_class_terms = 'https://dwc.tdwg.org/xml/tdwg_dwc_class_terms.xsd'
+    simple = 'https://dwc.tdwg.org/xml/tdwg_dwc_simple.xsd'
+    terms_csv = 'https://raw.githubusercontent.com/tdwg/dwc/master/vocabulary/term_versions.csv'
+    metadata = 'http://rs.tdwg.org/dwc/text/tdwg_dwc_text.xsd'
+
+
+@dataclass
+class GBIFUrls:
+    base_url = 'https://rs.gbif.org'
+    core_extensions = {
+        'occurrence': 'https://rs.gbif.org/core/dwc_occurrence_2020-07-15.xml',
+        'taxon': 'https://rs.gbif.org/core/dwc_taxon_2015-04-24.xml',
+        'event': 'https://rs.gbif.org/core/dwc_event_2016_06_21.xml'
+    }
+    extensions = {
+        'multimedia': 'https://rs.gbif.org/extension/gbif/1.0/multimedia.xml'
+    }
+    eml = 'http://rs.gbif.org/schema/eml-gbif-profile/1.1/eml.xsd'
+    thesaurus = 'http://rs.gbif.org/vocabulary/gbif/dataset_type.xml'
+
+
+@dataclass
+class XMLUrls:
+    xsi = 'http://www.w3.org/2001/XMLSchema-instance'
+    xs = 'http://www.w3.org/2001/XMLSchema'
+    xml = 'http://www.w3.org/XML/1998/namespace'
+    dc = 'http://purl.org/dc/terms'
+    eml = 'eml://ecoinformatics.org/eml-2.1.1'

--- a/ckanext/versioned_datastore/lib/downloads/dwc/utils.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/utils.py
@@ -1,0 +1,50 @@
+from io import BytesIO
+
+import requests
+from ckan.plugins import toolkit
+from lxml import etree
+
+parser = etree.XMLParser(recover=True)
+
+
+def load_schema(url, base_url=None):
+    # lxml does not like https urls, so use requests to get the bytes
+    r = requests.get(url)
+    content = BytesIO(r.content)
+    return etree.parse(content, base_url=base_url).getroot()
+
+
+def json_to_xml(tag, content):
+    if isinstance(content, tuple):
+        attrs = content[1]
+        content = content[0]
+    else:
+        attrs = {}
+
+    if isinstance(content, dict):
+        node = etree.Element(tag, **attrs)
+        for k, v in content.items():
+            for n in json_to_xml(k, v):
+                node.append(n)
+        return [node]
+    elif isinstance(content, list):
+        nodes = [item for e in content for item in json_to_xml(tag, e)]
+        return nodes
+    else:
+        node = etree.Element(tag, **attrs)
+        node.text = content
+        return [node]
+
+
+def get_setting(*config_names, default=None):
+    setting = None
+    for c in config_names:
+        setting = toolkit.config.get(c)
+        if setting is not None:
+            break
+    return setting or default
+
+
+class NSMap(dict):
+    def ns(self, key, tag):
+        return f'{{{self[key]}}}{tag}'

--- a/ckanext/versioned_datastore/lib/downloads/dwc/writer.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/writer.py
@@ -30,7 +30,7 @@ def dwc_writer(request, target_dir, field_counts):
     # available are from GBIF, and they're specified by name (as in urls.py).
     schema_args = {}
     # there can only be one core extension
-    core_ext = toolkit.config.get('ckanext.versioned_datastore.dwc_core_extension_name')
+    core_ext = toolkit.config.get('ckanext.versioned_datastore.dwc_core_extension_name', '')
     core_ext_url = GBIFUrls.core_extensions.get(core_ext.lower())
     if core_ext_url:
         schema_args['core_extension_url'] = core_ext_url

--- a/ckanext/versioned_datastore/lib/downloads/dwc/writer.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/writer.py
@@ -1,0 +1,85 @@
+import contextlib
+from collections import defaultdict
+
+from ckan.plugins import toolkit
+
+from .archive import Archive
+from .schema import Schema
+from .urls import GBIFUrls
+from ..utils import filter_data_fields, get_fields
+
+
+@contextlib.contextmanager
+def dwc_writer(request, target_dir, field_counts):
+    '''
+    Provides the functionality to write data to DarwinCore archives (https://dwc.tdwg.org).
+
+    This function is a context manager and when used with `with` will yield a write function. This
+    function takes 3 parameters - the elasticsearch hit object, the data dict from the hit and the
+    resource id the hit came from.
+
+    :param request: the download request object
+    :param target_dir: the target directory to put the data files in
+    :param field_counts:
+    :return: yields a write function
+    '''
+
+    schema_args = {}
+    core_ext = toolkit.config.get('ckanext.versioned_datastore.dwc_core_extension_name')
+    core_ext_url = GBIFUrls.core_extensions.get(core_ext.lower())
+    if core_ext_url:
+        schema_args['core_extension_url'] = core_ext_url
+    ext_names = [e.strip().lower() for e in
+                 toolkit.config.get('ckanext.versioned_datastore.dwc_extension_names', '').split(',')]
+    ext_urls = [GBIFUrls.extensions.get(e) for e in ext_names if e in GBIFUrls.extensions]
+    if len(ext_urls) > 0:
+        schema_args['extension_urls'] = ext_urls
+    schema_controller = Schema.load(
+        toolkit.config.get('ckanext.versioned_datastore.dwc_schema_cache'), **schema_args)
+
+    # there may be a better way to define this dynamically but it's static for now
+    default_extension_map = {'associatedMedia': 'Multimedia'}
+    extension_map = {k: v for k, v in default_extension_map.items() if v.lower() in ext_names}
+
+    if request.separate_files:
+        # files will be opened lazily and stored in this dict using the resource ids as keys
+        open_files = {}
+    else:
+        all_field_names = get_fields(field_counts, request.ignore_empty_fields)
+        # each 'Archive' contains multiple open files
+        open_file = Archive(schema_controller, request, target_dir).open(all_field_names,
+                                                                         extension_map)
+        # ensure that any request to get the open file for a given resource returns this archive
+        open_files = defaultdict(lambda: open_file)
+
+    try:
+        def write(hit, data, resource_id):
+            if request.separate_files and resource_id not in open_files:
+                resource_field_names = get_fields(field_counts, request.ignore_empty_fields,
+                                                  [resource_id])
+                archive = Archive(schema_controller, request, target_dir, resource_id).open(
+                    resource_field_names, extension_map)
+                # lazily open the archive for this resource id
+                open_files[resource_id] = archive
+            else:
+                archive = open_files[resource_id]
+
+            archive.initialise(data)
+
+            if request.ignore_empty_fields:
+                data = filter_data_fields(data, field_counts[resource_id])
+
+            # always add the resource ID
+            data['datasetID'] = resource_id
+
+            # and the record type
+            data['basisOfRecord'] = archive.schema.row_type_name
+
+            # write the data
+            archive.write_record(data)
+
+        yield write
+    finally:
+        # make sure we close all the files we opened
+        for open_file in open_files.values():
+            open_file.close()

--- a/ckanext/versioned_datastore/lib/downloads/dwc/writer.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/writer.py
@@ -3,9 +3,9 @@ from collections import defaultdict
 
 from ckan.plugins import toolkit
 
+from . import urls
 from .archive import Archive
 from .schema import Schema
-from .urls import GBIFUrls
 from ..utils import filter_data_fields, get_fields
 
 
@@ -26,19 +26,20 @@ def dwc_writer(request, target_dir, field_counts):
     '''
 
     # load the extensions from the config, if any are defined. Ideally this could be specified or
-    # overridden at runtime, but for now it's all just in ckan.ini. Currently the only extensions
-    # available are from GBIF, and they're specified by name (as in urls.py).
+    # overridden at runtime, but for now it's all just in ckan.ini. Extensions are specified by
+    # name (as in urls.py).
     schema_args = {}
     # there can only be one core extension
-    core_ext = toolkit.config.get('ckanext.versioned_datastore.dwc_core_extension_name', '')
-    core_ext_url = GBIFUrls.core_extensions.get(core_ext.lower())
-    if core_ext_url:
+    core_ext = toolkit.config.get('ckanext.versioned_datastore.dwc_core_extension_name')
+    if core_ext is not None and core_ext.lower() in urls.core_extensions:
+        core_ext_url = urls.core_extensions.get(core_ext.lower())
         schema_args['core_extension_url'] = core_ext_url
+
     # there can be multiple non-core extensions, separated by commas
     ext_names = [e.strip().lower() for e in
                  toolkit.config.get('ckanext.versioned_datastore.dwc_extension_names', '').split(
                      ',')]
-    ext_urls = [GBIFUrls.extensions.get(e) for e in ext_names if e in GBIFUrls.extensions]
+    ext_urls = [urls.extensions.get(e) for e in ext_names if e in urls.extensions]
     if len(ext_urls) > 0:
         schema_args['extension_urls'] = ext_urls
     schema_controller = Schema.load(

--- a/ckanext/versioned_datastore/lib/downloads/dwc/writer.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/writer.py
@@ -20,23 +20,31 @@ def dwc_writer(request, target_dir, field_counts):
 
     :param request: the download request object
     :param target_dir: the target directory to put the data files in
-    :param field_counts:
+    :param field_counts: a dict of resource ids -> fields -> counts used to determine which fields
+                         should be included in the csv file headers
     :return: yields a write function
     '''
 
+    # load the extensions from the config, if any are defined. Ideally this could be specified or
+    # overridden at runtime, but for now it's all just in ckan.ini. Currently the only extensions
+    # available are from GBIF, and they're specified by name (as in urls.py).
     schema_args = {}
+    # there can only be one core extension
     core_ext = toolkit.config.get('ckanext.versioned_datastore.dwc_core_extension_name')
     core_ext_url = GBIFUrls.core_extensions.get(core_ext.lower())
     if core_ext_url:
         schema_args['core_extension_url'] = core_ext_url
+    # there can be multiple non-core extensions, separated by commas
     ext_names = [e.strip().lower() for e in
-                 toolkit.config.get('ckanext.versioned_datastore.dwc_extension_names', '').split(',')]
+                 toolkit.config.get('ckanext.versioned_datastore.dwc_extension_names', '').split(
+                     ',')]
     ext_urls = [GBIFUrls.extensions.get(e) for e in ext_names if e in GBIFUrls.extensions]
     if len(ext_urls) > 0:
         schema_args['extension_urls'] = ext_urls
     schema_controller = Schema.load(
         toolkit.config.get('ckanext.versioned_datastore.dwc_schema_cache'), **schema_args)
 
+    # map field names to extension names; the field contains the data required for the extension.
     # there may be a better way to define this dynamically but it's static for now
     default_extension_map = {'associatedMedia': 'Multimedia'}
     extension_map = {k: v for k, v in default_extension_map.items() if v.lower() in ext_names}

--- a/ckanext/versioned_datastore/lib/downloads/dwc/writer.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/writer.py
@@ -25,20 +25,21 @@ def dwc_writer(request, target_dir, field_counts):
     :return: yields a write function
     '''
 
-    # load the extensions from the config, if any are defined. Ideally this could be specified or
-    # overridden at runtime, but for now it's all just in ckan.ini. Extensions are specified by
-    # name (as in urls.py).
+    # load the extensions, either from ckan.ini or from request args (request args take precedence).
+    # Extensions are specified by name (as in urls.py).
     schema_args = {}
     # there can only be one core extension
-    core_ext = toolkit.config.get('ckanext.versioned_datastore.dwc_core_extension_name')
+    core_ext = request.format_args.get('core_extension_name',
+                                       toolkit.config.get('ckanext.versioned_datastore.dwc_core_extension_name'))
     if core_ext is not None and core_ext.lower() in urls.core_extensions:
         core_ext_url = urls.core_extensions.get(core_ext.lower())
         schema_args['core_extension_url'] = core_ext_url
 
-    # there can be multiple non-core extensions, separated by commas
-    ext_names = [e.strip().lower() for e in
+    # there can be multiple non-core extensions, separated by commas in ckan.ini or supplied as a
+    # list in the request args
+    ext_names = request.format_args.get('extension_names', [e.strip().lower() for e in
                  toolkit.config.get('ckanext.versioned_datastore.dwc_extension_names', '').split(
-                     ',')]
+                     ',')])
     ext_urls = [urls.extensions.get(e) for e in ext_names if e in urls.extensions]
     if len(ext_urls) > 0:
         schema_args['extension_urls'] = ext_urls

--- a/ckanext/versioned_datastore/logic/schema.py
+++ b/ckanext/versioned_datastore/logic/schema.py
@@ -227,6 +227,7 @@ def datastore_queue_download():
         'separate_files': [ignore_missing, boolean_validator],
         'format': [ignore_missing, str],
         'ignore_empty_fields': [ignore_missing, boolean_validator],
+        'format_args': [ignore_missing, json_validator]
     }
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 with open('README.md', 'r') as f:
     __long_description__ = f.read()

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'elasticsearch>=6.0.0,<7.0.0',
         'elasticsearch-dsl>=6.0.0,<7.0.0',
         'jsonschema==3.0.0',
+        'pandas==1.4.1'
     ] + ['{0} @ {1}'.format(k, v) for k, v in dependencies.items()],
     dependency_links=list(dependencies.values()),
     entry_points= \


### PR DESCRIPTION
Adds a new download format - [DarwinCore Archives](https://dwc.tdwg.org/text). Closes #22.
- supports core extensions and non-core extensions (currently only configured to use GBIF extensions)
- extensions can be set in configs and overridden in request args
- optionally integrates with [ckanext-attribution](https://github.com/NaturalHistoryMuseum/ckanext-attribution) and [ckanext-query-dois](https://github.com/NaturalHistoryMuseum/ckanext-query-dois) to generate metadata (uses defaults if not available)
- also adds `format_args` request arg for all download types, for passing in extra options specific to the format