### PR TITLE
Add job timeouts

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -59,7 +59,8 @@ available at <a href="{{ download_url }}">here</a>.</p>
 
 
 def queue_download(email_address, download_id, query_hash, query, query_version, search,
-                   resource_ids_and_versions, separate_files, file_format, format_args, ignore_empty_fields):
+                   resource_ids_and_versions, separate_files, file_format, format_args,
+                   ignore_empty_fields):
     '''
     Queues a job which when run will download the data for the resource.
 
@@ -82,7 +83,8 @@ class DownloadRequest(object):
     '''
 
     def __init__(self, email_address, download_id, query_hash, query, query_version, search,
-                 resource_ids_and_versions, separate_files, file_format, format_args, ignore_empty_fields):
+                 resource_ids_and_versions, separate_files, file_format, format_args,
+                 ignore_empty_fields):
         self.email_address = email_address
         self.download_id = download_id
         self.query_hash = query_hash

--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -68,9 +68,9 @@ def queue_download(email_address, download_id, query_hash, query, query_version,
     request = DownloadRequest(email_address, download_id, query_hash, query, query_version, search,
                               resource_ids_and_versions, separate_files, file_format, format_args,
                               ignore_empty_fields)
-    # pass a timeout of 10 mins (600 seconds)
+    # pass a timeout of 1 hour (3600 seconds)
     return toolkit.enqueue_job(download, args=[request], queue='download', title=str(request),
-                               rq_kwargs={'timeout': 600})
+                               rq_kwargs={'timeout': 3600})
 
 
 class DownloadRequest(object):

--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -6,22 +6,20 @@ import shutil
 import socket
 import tempfile
 import zipfile
-from datetime import datetime
-from glob import iglob
-from traceback import format_exception_only
-
-import rq
 from ckan import model
-from ckan.lib import jobs, mailer
+from ckan.lib import mailer
 from ckan.plugins import toolkit, PluginImplementations
+from datetime import datetime
 from eevee.indexing.utils import get_elasticsearch_client
 from eevee.search import create_version_query
 from elasticsearch_dsl import Search
+from glob import iglob
 from jinja2 import Template
+from traceback import format_exception_only
 
+from .dwc import dwc_writer
 from .jsonl import jsonl_writer
 from .sv import sv_writer
-from .dwc import dwc_writer
 from .utils import calculate_field_counts
 from .. import common
 from ..datastore_utils import trim_index_name, prefix_resource

--- a/ckanext/versioned_datastore/lib/importing/queuing.py
+++ b/ckanext/versioned_datastore/lib/importing/queuing.py
@@ -34,7 +34,8 @@ def queue(function, request):
     :return: the queued job
     '''
     ensure_importing_queue_exists()
-    return toolkit.enqueue_job(function, args=[request], queue='importing', title=str(request))
+    return toolkit.enqueue_job(function, args=[request], queue='importing', title=str(request),
+                               rq_kwargs={'timeout': 600})
 
 
 def queue_import(resource, version, replace, records=None, api_key=None):

--- a/ckanext/versioned_datastore/lib/importing/queuing.py
+++ b/ckanext/versioned_datastore/lib/importing/queuing.py
@@ -5,16 +5,16 @@ from .importing import import_resource_data, ResourceImportRequest, ResourceDele
 from .indexing import index_resource, ResourceIndexRequest
 
 
-def queue(function, request):
+def queue(task, request):
     '''
-    Generic queueing function which ensures our special queue is setup first.
+    Generic queueing function which ensures we set common attributes when queueing the task.
 
-    :param function: the function to queue
+    :param task: the function to queue
     :param request: the queue request object
     :return: the queued job
     '''
     # pass a timeout of 1 hour (3600 seconds)
-    return toolkit.enqueue_job(function, args=[request], queue='importing', title=str(request),
+    return toolkit.enqueue_job(task, args=[request], queue='importing', title=str(request),
                                rq_kwargs={'timeout': 3600})
 
 


### PR DESCRIPTION
Add timeouts of 600 seconds to download and import jobs.