### PR TITLE
Extend the elasticsearch client timeout to 30s instead of 10s

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -163,7 +163,7 @@ def download(request):
     try:
         es_client = get_elasticsearch_client(common.CONFIG, sniff_on_start=True, sniffer_timeout=60,
                                              sniff_on_connection_fail=True, sniff_timeout=10,
-                                             http_compress=False)
+                                             http_compress=False, timeout=30)
 
         # this manifest will be written out as JSON and put in the download zip
         manifest = {

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = '3.1.2'
+__version__ = '3.1.3'
 
 with open('README.md', 'r') as f:
     __long_description__ = f.read()


### PR DESCRIPTION
Generally this isn't a problem, but for very large queries (e.g. geo polygon type queries) timeouts can occur:

`elasticsearch.exceptions.ConnectionTimeout: ConnectionTimeout caused by - ReadTimeoutError(HTTPConnectionPool(host='157.140.17.34', port=9200): Read timed out. (read timeout=10))`

This just extends the timeout a little.