### PR TITLE
Add an interface hook to modify request before writing download file

### DIFF
--- a/ckanext/versioned_datastore/interfaces.py
+++ b/ckanext/versioned_datastore/interfaces.py
@@ -246,3 +246,12 @@ class IVersionedDatastoreDownloads(interfaces.Interface):
         :return: context templating dict
         '''
         return context
+
+    def download_before_write(self, request):
+        '''
+        Hook allowing other extensions to access and modify the request before the search is run
+        and the download file is created.
+        :param request: the DownloadRequest object
+        :return: the request
+        '''
+        return request

--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -183,6 +183,9 @@ def download(request):
         # keep track of the resource record counts
         resource_counts = {}
 
+        for plugin in PluginImplementations(IVersionedDatastoreDownloads):
+            request = plugin.download_before_write(request)
+
         with writer_function(request, target_dir, field_counts) as writer:
             # handle each resource individually. We could search across all resources at the same
             # but we don't need to seeing as we're not doing sorting here. By handling each index


### PR DESCRIPTION
Particularly useful for extensions like [ckanext-query-dois](https://github.com/NaturalHistoryMuseum/ckanext-query-dois), so any download/search metadata (e.g. a DOI) can be created _before_ the download file is created and can then be included in the file.