### PR TITLE
Switch to setup.cfg

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,0 @@
-mock
-pytest>=4.6.5
-pytest-cov>=2.7.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - elasticsearch
       - mongodb
     volumes:
-      - .:/srv/app/src/ckanext-versioned-datastore
+      - ./ckanext:/srv/app/src/ckanext-versioned-datastore/ckanext
 
   solr:
     build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN pip3 install --upgrade pip
 # fixes this https://github.com/ckan/ckan/issues/5570
 RUN pip3 install pytest-ckan
 
-# install the dependencies
+# install the base + test dependencies
 RUN pip3 install -e .[test]
 
 # this entrypoint ensures our service dependencies (postgresql, solr and redis) are running before

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,9 +13,7 @@ RUN pip3 install --upgrade pip
 RUN pip3 install pytest-ckan
 
 # install the dependencies
-RUN python3 setup.py develop && \
-    pip3 install -r requirements.txt && \
-    pip3 install -r dev_requirements.txt
+RUN pip3 install -e .[test]
 
 # this entrypoint ensures our service dependencies (postgresql, solr and redis) are running before
 # running the cmd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-# install from setup.py
-.
-
-# dev overrides/additional libraries

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,47 @@
+[metadata]
+name = ckanext-versioned-datastore
+version = 3.1.3
+description = A CKAN extension providing a versioned datastore using MongoDB and Elasticsearch
+long_description = file: README.md
+license_files = LICENSE
+author = Natural History Museum
+author_email = data@nhm.ac.uk
+url = https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore
+keywords = CKAN data elastic versioning
+classifiers =
+    Development Status :: 5 - Production/Stable
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
+    Programming Language :: Python
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+
+[options]
+packages = find:
+install_requires =
+    backports.csv==1.0.6
+    cchardet==2.1.4
+    openpyxl==2.5.8
+    requests
+    six>=1.11.0
+    xlrd==1.1.0
+    elasticsearch>=6.0.0,<7.0.0
+    elasticsearch-dsl>=6.0.0,<7.0.0
+    jsonschema==3.0.0
+    pandas==1.4.1
+    eevee @ git+https://github.com/NaturalHistoryMuseum/eevee@v1.2.3#egg=eevee-1.2.3
+
+[options.extras_require]
+test =
+    mock
+    pytest>=4.6.5
+    pytest-cov>=2.7.1
+
+[options.packages.find]
+exclude =
+    tests
+
+[options.entry_points]
+ckan.plugins =
+    versioned_datastore=ckanext.versioned_datastore.plugin:VersionedSearchPlugin

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,4 +44,4 @@ exclude =
 
 [options.entry_points]
 ckan.plugins =
-    versioned_datastore=ckanext.versioned_datastore.plugin:VersionedSearchPlugin
+    versioned_datastore = ckanext.versioned_datastore.plugin:VersionedSearchPlugin

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ckanext-versioned-datastore
-version = 3.1.3
+version = 3.2.0
 description = A CKAN extension providing a versioned datastore using MongoDB and Elasticsearch
 long_description = file: README.md
 license_files = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,57 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 #
 # This file is part of ckanext-versioned-datastore
 # Created by the Natural History Museum in London, UK
 
-from setuptools import find_packages, setup
+import setuptools
 
-__version__ = '3.1.3'
-
-with open('README.md', 'r') as f:
-    __long_description__ = f.read()
-
-dependencies = {'eevee': 'git+https://github.com/NaturalHistoryMuseum/eevee@v1.2.3#egg=eevee-1.2.3'}
-
-setup(
-    name='ckanext-versioned-datastore',
-    version=__version__,
-    description='A CKAN extension providing a versioned datastore using MongoDB and Elasticsearch.',
-    long_description=__long_description__,
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-    ],
-    keywords='CKAN data elastic versioning',
-    author='Natural History Museum',
-    author_email='data@nhm.ac.uk',
-    url='https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore',
-    license='GNU GPLv3',
-    packages=find_packages(exclude=['tests']),
-    namespace_packages=['ckanext', 'ckanext.versioned_datastore'],
-    include_package_data=True,
-    zip_safe=False,
-    install_requires=[
-        'backports.csv==1.0.6',
-        'cchardet==2.1.4',
-        'openpyxl==2.5.8',
-        'requests',
-        'six>=1.11.0',
-        'xlrd==1.1.0',
-        'elasticsearch>=6.0.0,<7.0.0',
-        'elasticsearch-dsl>=6.0.0,<7.0.0',
-        'jsonschema==3.0.0',
-        'pandas==1.4.1'
-    ] + ['{0} @ {1}'.format(k, v) for k, v in dependencies.items()],
-    dependency_links=list(dependencies.values()),
-    entry_points= \
-        '''
-        [ckan.plugins]
-            versioned_datastore=ckanext.versioned_datastore.plugin:VersionedSearchPlugin
-        ''',
-    )
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
More modern! Bit better! Also, fixes the problem where when ckanext-nhm installs this repo as a dependency but doesn't install all the dependencies correctly (specifically, nhm -> this repo -> pandas but then fails to install numpy).