### PR TITLE
Remove pandas dependency and rewrite affected section

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/dwc/schema_parts.py
+++ b/ckanext/versioned_datastore/lib/downloads/dwc/schema_parts.py
@@ -57,9 +57,9 @@ class Prop(object):
         if row_source is None and xml_element_source is None:
             raise Exception('At least one source required.')
         if row_source is not None:
-            self.name = row_source.term_localName
-            self.iri = row_source.term_iri
-            self.domain = row_source.organized_in
+            self.name = row_source['term_localName']
+            self.iri = row_source['term_iri']
+            self.domain = row_source['organized_in']
         else:
             self.name = xml_element_source.attrib['name']
             self.iri = xml_element_source.attrib.get('qualName')
@@ -154,10 +154,10 @@ class Domain(object):
         return next(p for p in self.props(schema) if p.is_identifier)
 
     @classmethod
-    def create(cls, source):
-        name = source.term_localName
-        label = source.label
-        iri = source.term_iri
+    def create(cls, source: dict):
+        name = source['term_localName']
+        label = source['label']
+        iri = source['term_iri']
         return cls(name, label, iri)
 
     def serialise(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,9 @@ install_requires =
     elasticsearch>=6.0.0,<7.0.0
     elasticsearch-dsl>=6.0.0,<7.0.0
     jsonschema==3.0.0
-    pandas==1.4.1
+    pyfunctional==1.4.3
+    toolz==0.11.2
+    whatever==0.6
     eevee @ git+https://github.com/NaturalHistoryMuseum/eevee@v1.2.3#egg=eevee-1.2.3
 
 [options.extras_require]


### PR DESCRIPTION
Soooooo. The way this was done in pandas was much nicer than the new implementation but the inclusion of pandas for this one use isn't worth the downside: [25 minute docker builds](https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/actions/runs/2036137169)!

The docker image in this repo is based on the ckan-dev docker image which in turn is based on alpine linux. When installing pandas (and therefore numpy) on a normal libc based linux system (e.g. an ubuntu based docker image) you get a pre-compiled wheel and the install is very fast. Alpine linux doesn't use libc and therefore when pandas and numpy are installed the source is downloaded and compiled. This takes a really long time cause it's an enormously complicated library - usually somewhere in the region of 25-30 mins.

The only way (currently) to get round this and keep pandas would be to replace the ckan-dev docker base with something else, like a homebrewed ckan image based on ubuntu. Given the section of code using pandas isn't critically dependant on pandas (it could be rewritten in a few different ways, including the way it's done in this commit), it makes more sense at this point to remove it than change the docker setup. However, there's no reason we couldn't change the docker setup in the future and bring back the pandas dependency.

Also worth noting, this problem exists on the [ckanext-attribution](https://github.com/NaturalHistoryMuseum/ckanext-attribution) repo too, but over there the numpy install is for spacy which is like proper needed. We may need to create our own base ckan image built on ubuntu.