### PR TITLE
Download with slug or DOI

### DIFF
--- a/ckanext/versioned_datastore/logic/schema.py
+++ b/ckanext/versioned_datastore/logic/schema.py
@@ -229,6 +229,7 @@ def datastore_queue_download():
         'ignore_empty_fields': [ignore_missing, boolean_validator],
         'format_args': [ignore_missing, json_validator],
         'transform': [ignore_missing, json_validator],
+        'slug_or_doi': [ignore_missing, str]
     }
 
 

--- a/ckanext/versioned_datastore/routes/search.py
+++ b/ckanext/versioned_datastore/routes/search.py
@@ -6,6 +6,6 @@ blueprint = Blueprint(name='search', import_name=__name__)
 
 
 @blueprint.route('/search')
-@blueprint.route('/search/<slug>')
+@blueprint.route('/search/<path:slug>')
 def view(slug=''):
     return toolkit.render('search/search.html', extra_vars={'slug': slug})


### PR DESCRIPTION
- `datastore_resolve_slug` now resolves DOIs as well as slugs (slugs have priority)
- added `slug_or_doi` param to `datastore_queue_download` so a saved query can be used instead of having to provide the whole query every time

closes #57 