### PR TITLE
Add an XLSX file download option

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -20,6 +20,7 @@ from traceback import format_exception_only
 from .dwc import dwc_writer
 from .jsonl import jsonl_writer
 from .sv import sv_writer
+from .xlsx import xlsx_writer
 from .utils import calculate_field_counts
 from .transform import Transform
 from .. import common
@@ -32,7 +33,8 @@ format_registry = {
     'csv': functools.partial(sv_writer, dialect='excel', extension='csv'),
     'tsv': functools.partial(sv_writer, dialect='excel-tab', extension='tsv'),
     'jsonl': jsonl_writer,
-    'dwc': dwc_writer
+    'dwc': dwc_writer,
+    'xlsx': xlsx_writer,
 }
 
 default_body = '''

--- a/ckanext/versioned_datastore/lib/downloads/xlsx.py
+++ b/ckanext/versioned_datastore/lib/downloads/xlsx.py
@@ -1,0 +1,102 @@
+import contextlib
+from collections import defaultdict
+from pathlib import Path
+from typing import List, Dict
+
+from openpyxl import Workbook
+
+from .sv import flatten_dict
+from .utils import filter_data_fields, get_fields
+
+RESOURCE_ID_FIELD_NAME = 'Source resource ID'
+DEFAULT_SHEET_NAME = 'Data'
+ALL_IN_ONE_FILE_NAME = 'data.xlsx'
+
+
+class WorkbookWithFields:
+    '''
+    Class to keep a Workbook and the associated fields in use within it together, plus some
+    convenience methods for adding and saving data.
+    '''
+
+    def __init__(self, fields: List[str]):
+        '''
+        :param fields: a list of field names
+        '''
+        self.fields = fields
+        # the write only workbook avoids storing the workbook in memory and thus dodges running out
+        # of RAM, see: https://openpyxl.readthedocs.io/en/stable/optimized.html#write-only-mode.
+        # Note that there are some restrictions as to what you can do with a write only workbook but
+        # we don't run into any of them in the current implementation and we need it so that this
+        # writer doesn't eat all our RAM (as it says in the doc, RAM usage can be 50x file size! :O)
+        self.workbook = Workbook(write_only=True)
+        self.workbook.create_sheet(DEFAULT_SHEET_NAME)
+        self.workbook.active.append(fields)
+
+    def add(self, row: Dict[str, str]):
+        '''
+        Add a row to the workbook's active sheet.
+
+        :param row: the row of data as a dict
+        '''
+        self.workbook.active.append(row.get(field) for field in self.fields)
+
+    def save(self, path: Path):
+        '''
+        Write the workbook to disk. This can only be called once (see write only workbook mode).
+
+        :param path: the path to write the workbook to
+        :return:
+        '''
+        self.workbook.save(path)
+
+
+@contextlib.contextmanager
+def xlsx_writer(request, target_dir, field_counts):
+    '''
+    An XLSX (i.e. Excel speadsheet) writer.
+
+    :param request: the download request object
+    :param target_dir: the directory to save the data to
+    :param field_counts: a dict of resource ids -> fields -> counts used to determine which fields
+                         should be included in the xlsx file headers
+    :return: yields a write function
+    '''
+    if request.separate_files:
+        # map of resource ids to workbooks
+        workbooks = {}
+    else:
+        all_field_names = get_fields(field_counts, request.ignore_empty_fields)
+        # add the special resource id field name to the start
+        all_field_names.insert(0, RESOURCE_ID_FIELD_NAME)
+        workbook = WorkbookWithFields(all_field_names)
+        # create a defaultdict which always returns the workbook we just created for all the data
+        workbooks = defaultdict(lambda: workbook)
+
+    try:
+        def write(hit, data, resource_id):
+            if request.separate_files and resource_id not in workbooks:
+                field_names = get_fields(field_counts, request.ignore_empty_fields, [resource_id])
+                workbooks[resource_id] = WorkbookWithFields(field_names)
+
+            if request.ignore_empty_fields:
+                data = filter_data_fields(data, field_counts[resource_id])
+
+            if not request.separate_files:
+                # if the data is being written into one file we need to indicate which resource the
+                # data came from, this is how we do that
+                data['Source resource ID'] = resource_id
+
+            row = flatten_dict(data)
+            workbooks[resource_id].add(row)
+
+        yield write
+    finally:
+        target_path = Path(target_dir)
+        if request.separate_files:
+            # save each workbook out in turn
+            for res_id, workbook_with_fields in workbooks.items():
+                workbook_with_fields.save(target_path / f'{res_id}.xlsx')
+        else:
+            # there should only be one workbook in the workbooks dict so grab it and save it
+            next(iter(workbooks.values())).save(target_path / ALL_IN_ONE_FILE_NAME)

--- a/ckanext/versioned_datastore/lib/downloads/xlsx.py
+++ b/ckanext/versioned_datastore/lib/downloads/xlsx.py
@@ -82,12 +82,13 @@ def xlsx_writer(request, target_dir, field_counts):
             if request.ignore_empty_fields:
                 data = filter_data_fields(data, field_counts[resource_id])
 
+            row = flatten_dict(data)
+
             if not request.separate_files:
                 # if the data is being written into one file we need to indicate which resource the
                 # data came from, this is how we do that
-                data['Source resource ID'] = resource_id
+                row['Source resource ID'] = resource_id
 
-            row = flatten_dict(data)
             workbooks[resource_id].add(row)
 
         yield write

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,7 @@ services:
       - ./tests:/srv/app/src/ckanext-versioned-datastore/tests
 
   solr:
-    build:
-      context: https://github.com/okfn/docker-ckan.git#:solr
+    image: ckan/ckan-solr:2.9
     logging:
       driver: none
 

--- a/tests/test_xlsx_downloader.py
+++ b/tests/test_xlsx_downloader.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -22,11 +23,86 @@ def test_xlsx_single(tmpdir: Path):
 
     workbook = load_workbook(filename=data_file)
     rows = list(workbook[DEFAULT_SHEET_NAME].rows)
+    assert len(rows) == 2
+
     header = list(cell.value for cell in rows[0])
     expected_headers = [RESOURCE_ID_FIELD_NAME] + sorted(data)
     assert header == expected_headers
 
-    for row in rows[1:]:
+    row = rows[1]
+    row_data = dict(zip(header, [cell.value for cell in row]))
+    assert row_data.pop(RESOURCE_ID_FIELD_NAME) == resource_id
+    assert row_data == data
+
+
+def test_xlsx_multiple_one_file(tmpdir: Path):
+    data_a = {'field1': 'A', 'field2': 'B', 'field3': 'C'}
+    data_b = {'field5': 'A', 'field1': 'B', 'field7': 'C'}
+    resource_id_a = 'resource-a'
+    resource_id_b = 'resource-b'
+    field_counts = {
+        resource_id_a: {field: 10 for field in data_a},
+        resource_id_b: {field: 10 for field in data_b},
+    }
+    request = MagicMock(separate_files=False, ignore_empty_fields=False)
+    hit = MagicMock()
+
+    with xlsx_writer(request, tmpdir, field_counts) as write:
+        write(hit, data_a, resource_id_a)
+        write(hit, data_b, resource_id_b)
+
+    data_file = tmpdir / ALL_IN_ONE_FILE_NAME
+    assert data_file.exists()
+
+    workbook = load_workbook(filename=data_file)
+    rows = list(workbook[DEFAULT_SHEET_NAME].rows)
+    header = list(cell.value for cell in rows[0])
+    expected_headers = [RESOURCE_ID_FIELD_NAME] + sorted(set(chain(data_a, data_b)))
+    assert header == expected_headers
+
+    row_a = rows[1]
+    row_a_data = dict(zip(header, [cell.value for cell in row_a]))
+    assert row_a_data.pop(RESOURCE_ID_FIELD_NAME) == resource_id_a
+    assert row_a_data.pop('field5') is None
+    assert row_a_data.pop('field7') is None
+    assert row_a_data == data_a
+
+    row_b = rows[2]
+    row_b_data = dict(zip(header, [cell.value for cell in row_b]))
+    assert row_b_data.pop(RESOURCE_ID_FIELD_NAME) == resource_id_b
+    assert row_b_data.pop('field2') is None
+    assert row_b_data.pop('field3') is None
+    assert row_b_data == data_b
+
+
+def test_xlsx_multiple_separate_file(tmpdir: Path):
+    data_a = {'field1': 'A', 'field2': 'B', 'field3': 'C'}
+    data_b = {'field5': 'A', 'field1': 'B', 'field7': 'C'}
+    resource_id_a = 'resource-a'
+    resource_id_b = 'resource-b'
+    field_counts = {
+        resource_id_a: {field: 10 for field in data_a},
+        resource_id_b: {field: 10 for field in data_b},
+    }
+    request = MagicMock(separate_files=True, ignore_empty_fields=False)
+    hit = MagicMock()
+
+    with xlsx_writer(request, tmpdir, field_counts) as write:
+        write(hit, data_a, resource_id_a)
+        write(hit, data_b, resource_id_b)
+
+    for resource_id, data in [(resource_id_a, data_a), (resource_id_b, data_b)]:
+        data_file = tmpdir / f'{resource_id}.xlsx'
+        assert data_file.exists()
+
+        workbook = load_workbook(filename=data_file)
+        rows = list(workbook[DEFAULT_SHEET_NAME].rows)
+        assert len(rows) == 2
+
+        header = list(cell.value for cell in rows[0])
+        expected_headers = sorted(data)
+        assert header == expected_headers
+
+        row = rows[1]
         row_data = dict(zip(header, [cell.value for cell in row]))
-        assert row_data.pop(RESOURCE_ID_FIELD_NAME) == resource_id
         assert row_data == data

--- a/tests/test_xlsx_downloader.py
+++ b/tests/test_xlsx_downloader.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from openpyxl import load_workbook
+
+from ckanext.versioned_datastore.lib.downloads.xlsx import xlsx_writer, ALL_IN_ONE_FILE_NAME, \
+    DEFAULT_SHEET_NAME, RESOURCE_ID_FIELD_NAME
+
+
+def test_xlsx_single(tmpdir: Path):
+    data = {'field1': 'A', 'field2': 'B', 'field3': 'C'}
+    resource_id = 'resource-a'
+    field_counts = {resource_id: {field: 10 for field in data}}
+    request = MagicMock(separate_files=False, ignore_empty_fields=False)
+    hit = MagicMock()
+
+    with xlsx_writer(request, tmpdir, field_counts) as write:
+        write(hit, data, resource_id)
+
+    data_file = tmpdir / ALL_IN_ONE_FILE_NAME
+    assert data_file.exists()
+
+    workbook = load_workbook(filename=data_file)
+    rows = list(workbook[DEFAULT_SHEET_NAME].rows)
+    header = list(cell.value for cell in rows[0])
+    expected_headers = [RESOURCE_ID_FIELD_NAME] + sorted(data)
+    assert header == expected_headers
+
+    for row in rows[1:]:
+        row_data = dict(zip(header, [cell.value for cell in row]))
+        assert row_data.pop(RESOURCE_ID_FIELD_NAME) == resource_id
+        assert row_data == data


### PR DESCRIPTION
Fixes https://github.com/NaturalHistoryMuseum/data-portal/issues/437 by allowing users to download the data in XLSX format and use it straight up instead of in CSV and importing it.