### PR TITLE
Add datastore_edit_slug action

### DIFF
--- a/ckanext/versioned_datastore/logic/actions/help.py
+++ b/ckanext/versioned_datastore/logic/actions/help.py
@@ -718,3 +718,19 @@ Params:
 The result of this action is a dictionary with the following keys:
 :rtype: an integer count
 '''
+
+datastore_edit_slug = '''
+Add or modify the reserved slug for a query. Reserved slugs can only be replaced by sysadmins, but
+if one has not been added yet for a query, any logged-in user can supply it.
+
+Params:
+
+:param current_slug: the slug currently referencing the search (reserved or non-reserved)
+:type current_slug: str
+:param new_reserved_slug: the string to use as the new reserved slug
+:type new_reserved_slug: str
+
+Returns:
+
+:rtype: bool
+'''

--- a/ckanext/versioned_datastore/logic/actions/multisearch.py
+++ b/ckanext/versioned_datastore/logic/actions/multisearch.py
@@ -371,3 +371,15 @@ def datastore_hash_query(query=None, query_version=None):
         raise toolkit.ValidationError(e.message)
 
     return hash_query(query, query_version)
+
+
+@action(schema.datastore_edit_slug(), help.datastore_edit_slug, toolkit.side_effect_free)
+def datastore_edit_slug(context, current_slug, new_reserved_slug):
+    slug = resolve_slug(current_slug)
+    if slug is None:
+        raise toolkit.Invalid(f'The slug {current_slug} does not exist')
+    if slug.reserved_pretty_slug and not context['auth_user_obj'].sysadmin:
+        raise toolkit.NotAuthorized('Only sysadmins can replace existing reserved slugs.')
+    slug.reserved_pretty_slug=new_reserved_slug.lower()
+    slug.commit()
+    return slug.as_dict()

--- a/ckanext/versioned_datastore/logic/actions/multisearch.py
+++ b/ckanext/versioned_datastore/logic/actions/multisearch.py
@@ -195,6 +195,7 @@ def datastore_create_slug(context, query=None, query_version=None, version=None,
     return {
         'slug': slug.get_slug_string(),
         'is_new': is_new,
+        'is_reserved': slug.reserved_pretty_slug == slug.get_slug_string()
     }
 
 

--- a/ckanext/versioned_datastore/logic/auth.py
+++ b/ckanext/versioned_datastore/logic/auth.py
@@ -143,3 +143,9 @@ def datastore_get_latest_query_schema_version(context, data_dict):
 def datastore_count(context, data_dict):
     # allow access to everyone
     return {'success': True}
+
+
+@toolkit.auth_disallow_anonymous_access
+def datastore_edit_slug(context, data_dict):
+    # only allow logged-in users
+    return {'success': True}

--- a/ckanext/versioned_datastore/logic/schema.py
+++ b/ckanext/versioned_datastore/logic/schema.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from ckan.plugins import toolkit
 from ckanext.datastore.logic.schema import json_validator, unicode_or_json_validator
@@ -75,6 +76,18 @@ def list_validator(value, context):
         return value
     else:
         raise toolkit.Invalid('Value must be a list')
+
+
+def url_safe(value, context):
+    '''
+    Checks if the value is safe to be included in a URL as a slug.
+    :param value: the value to check
+    :param context: the context in which to check
+    '''
+    if not re.match('^[A-Za-z0-9-_]+$', value):
+        raise toolkit.Invalid('Only a-z, 0-9, hyphens (-) and underscores (_) are valid characters')
+    else:
+        return value
 
 
 def datastore_search():
@@ -255,4 +268,11 @@ def datastore_hash_query():
 def datastore_is_datastore_resource():
     return {
         'resource_id': [not_missing, not_empty, resource_id_exists]
+    }
+
+
+def datastore_edit_slug():
+    return {
+        'current_slug': [str, not_missing, not_empty],
+        'new_reserved_slug': [str, not_missing, not_empty, url_safe]
     }

--- a/ckanext/versioned_datastore/plugin.py
+++ b/ckanext/versioned_datastore/plugin.py
@@ -67,6 +67,7 @@ class VersionedSearchPlugin(SingletonPlugin):
             'datastore_is_datastore_resource': auth.datastore_hash_query,
             'datastore_get_latest_query_schema_version':
                 auth.datastore_get_latest_query_schema_version,
+            'datastore_edit_slug': auth.datastore_edit_slug,
         }
 
     # ITemplateHelpers


### PR DESCRIPTION
Allows users to edit or add reserved slugs for queries. Any logged-in user can add a reserved slug where one does not already exist, but only sysadmins can edit or replace existing ones.