### PR TITLE
New functionality to allow deprecating ckanpackager

### DIFF
--- a/ckanext/versioned_datastore/helpers.py
+++ b/ckanext/versioned_datastore/helpers.py
@@ -4,6 +4,7 @@ from datetime import date
 
 from .lib.common import ALL_FORMATS
 from .lib.importing import stats
+from .lib.query.slugs import create_nav_slug
 
 
 def is_duplicate_ingestion(stat):
@@ -150,3 +151,15 @@ def latest_item_version(resource_id, record_id=None):
 
     versions = toolkit.get_action(action)({}, data_dict)
     return versions[-1]
+
+
+def nav_slug(
+    query=None, version=None, resource_ids=None, resource_ids_and_versions=None
+):
+    """
+    Just a helper proxy for create_nav_slug.
+    """
+    is_new, slug = create_nav_slug(
+        {}, query or {}, version, resource_ids, resource_ids_and_versions
+    )
+    return slug.get_slug_string()

--- a/ckanext/versioned_datastore/lib/basic_query/utils.py
+++ b/ckanext/versioned_datastore/lib/basic_query/utils.py
@@ -7,6 +7,7 @@ from ckan.lib.search import SearchIndexError
 from .. import common
 from ..datastore_utils import prefix_resource, prefix_field
 from ..importing.details import get_all_details
+import json
 
 
 def run_search(search, indexes, version=None):
@@ -199,6 +200,8 @@ def convert_to_multisearch(query):
                 values = [values]
             if field == '__geo__':
                 for value in values:
+                    if isinstance(value, str):
+                        value = json.loads(value)
                     if value['type'] == 'Polygon':
                         filter_list.append({'geo_custom_area': [value['coordinates']]})
                     else:

--- a/ckanext/versioned_datastore/lib/common.py
+++ b/ckanext/versioned_datastore/lib/common.py
@@ -26,6 +26,8 @@ CONFIG = None
 SEARCH_HELPER = None
 ES_CLIENT = None
 
+NON_DATASTORE_VERSION = -1
+
 
 def setup(ckan_config):
     """

--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -469,6 +469,9 @@ class DownloadRunManager:
                 res = resource_show({}, {'id': resource_id})
                 if res.get('url_type') == 'upload':
                     upload = uploader.get_resource_uploader(res)
+                    if not upload.storage_path:
+                        # if ckan.storage_path is not set
+                        raise Exception('Non-datastore uploads are not configured.')
                     filepath = upload.get_path(res['id'])
                     original_filename = res.get('url', '').split('/')[-1]
                     fileext = (

--- a/ckanext/versioned_datastore/lib/downloads/query.py
+++ b/ckanext/versioned_datastore/lib/downloads/query.py
@@ -1,21 +1,15 @@
-from datetime import datetime
+import hashlib
 
 from ckan.plugins import toolkit
-from splitgill.utils import to_timestamp
-
+from ..basic_query.utils import convert_to_multisearch
 from ..query.schema import (
     get_latest_query_version,
     hash_query,
     translate_query,
     validate_query,
 )
-from ..query.utils import get_available_datastore_resources, get_resources_and_versions
-from .. import common
-from ..datastore_utils import prefix_resource
+from ..query.utils import get_resources_and_versions
 from ...logic.actions.meta.arg_objects import QueryArgs
-import hashlib
-from ..basic_query.utils import convert_to_multisearch
-from jsonschema.exceptions import ValidationError
 
 
 class Query(object):
@@ -60,12 +54,12 @@ class Query(object):
         # setup the query
         if query is None:
             query = {}
+        if query_version and query_version.lower().startswith('v0'):
+            # this is an old/basic query so we need to convert it first
+            query = convert_to_multisearch(query)
+            query_version = None
         if query_version is None:
             query_version = get_latest_query_version()
-            try:
-                validate_query(query, query_version)
-            except ValidationError:
-                query = convert_to_multisearch(query)
 
         return cls(query, query_version, rounded_resource_ids_and_versions)
 

--- a/ckanext/versioned_datastore/lib/downloads/query.py
+++ b/ckanext/versioned_datastore/lib/downloads/query.py
@@ -27,7 +27,7 @@ class Query(object):
         return self._search
 
     @classmethod
-    def from_query_args(cls, query_args: QueryArgs):
+    def from_query_args(cls, query_args: QueryArgs, allow_non_datastore=False):
         query = query_args.query
         query_version = query_args.query_version
         resource_ids = query_args.resource_ids
@@ -48,7 +48,9 @@ class Query(object):
                 pass
 
         resource_ids, rounded_resource_ids_and_versions = get_resources_and_versions(
-            resource_ids, resource_ids_and_versions
+            resource_ids,
+            resource_ids_and_versions,
+            allow_non_datastore=allow_non_datastore,
         )
 
         # setup the query

--- a/ckanext/versioned_datastore/lib/downloads/query.py
+++ b/ckanext/versioned_datastore/lib/downloads/query.py
@@ -14,6 +14,8 @@ from .. import common
 from ..datastore_utils import prefix_resource
 from ...logic.actions.meta.arg_objects import QueryArgs
 import hashlib
+from ..basic_query.utils import convert_to_multisearch
+from jsonschema.exceptions import ValidationError
 
 
 class Query(object):
@@ -88,6 +90,10 @@ class Query(object):
             query = {}
         if query_version is None:
             query_version = get_latest_query_version()
+            try:
+                validate_query(query, query_version)
+            except ValidationError:
+                query = convert_to_multisearch(query)
 
         return cls(query, query_version, rounded_resource_ids_and_versions)
 

--- a/ckanext/versioned_datastore/lib/downloads/utils.py
+++ b/ckanext/versioned_datastore/lib/downloads/utils.py
@@ -4,6 +4,7 @@ from fastavro import parse_schema
 from splitgill.search import create_version_query
 
 from .query import Query
+from .. import common
 from ..datastore_utils import (
     prefix_resource,
     prefix_field,
@@ -22,7 +23,11 @@ def get_schemas(query: Query, es_client: Elasticsearch):
     """
     resource_mapping = es_client.indices.get_mapping(
         index=','.join(
-            [prefix_resource(r) for r in query.resource_ids_and_versions.keys()]
+            [
+                prefix_resource(r)
+                for r, v in query.resource_ids_and_versions.items()
+                if v != common.NON_DATASTORE_VERSION
+            ]
         )
     )
 

--- a/ckanext/versioned_datastore/lib/query/slugs.py
+++ b/ckanext/versioned_datastore/lib/query/slugs.py
@@ -1,5 +1,7 @@
+import datetime
 import hashlib
 import random
+import logging
 
 from ckan import model
 from ckan.plugins import toolkit
@@ -9,7 +11,9 @@ from .schema import get_latest_query_version, hash_query
 from .schema import validate_query
 from .slug_words import list_one, list_two, list_three
 from .utils import get_available_datastore_resources, get_resources_and_versions
-from ...model.slugs import DatastoreSlug
+from ...model.slugs import DatastoreSlug, NavigationalSlug
+
+log = logging.getLogger(__name__)
 
 
 def generate_query_hash(
@@ -143,13 +147,66 @@ def create_slug(
     return True, new_slug
 
 
-def resolve_slug(slug):
+def create_nav_slug(
+    context, query, version=None, resource_ids=None, resource_ids_and_versions=None
+):
+    try:
+        # clear old slugs before we make new ones
+        clean_nav_slugs()
+    except Exception as e:
+        # if it fails, log it and move on
+        log.debug(f'Cleaning nav slugs failed: {e}')
+
+    query_version = get_latest_query_version()  # it should always be the latest version
+    validate_query(query, query_version)
+
+    resource_ids, resource_ids_and_versions = get_resources_and_versions(
+        resource_ids, resource_ids_and_versions, version
+    )
+
+    query_hash = generate_query_hash(
+        query, query_version, version, resource_ids, resource_ids_and_versions
+    )
+
+    existing_slug = (
+        model.Session.query(NavigationalSlug)
+        .filter(NavigationalSlug.query_hash == query_hash)
+        .first()
+    )
+
+    if existing_slug is not None:
+        return False, existing_slug
+
+    new_slug = NavigationalSlug(
+        query_hash=query_hash,
+        query=query,
+        resource_ids_and_versions=resource_ids_and_versions,
+    )
+    new_slug.save()
+
+    return True, new_slug
+
+
+def resolve_slug(slug, allow_nav=True):
     """
     Resolves the given slug and returns it if it's found, otherwise None is returned.
 
     :param slug: the slug
+    :param allow_nav: allow resolving to a navigational slug
     :return: a DatastoreSlug object or None if the slug couldn't be found
     """
+    if slug.startswith(NavigationalSlug.prefix) and allow_nav:
+        try:
+            # clean old slugs because we don't want old ones to continue resolving
+            clean_nav_slugs()
+        except Exception as e:
+            # if it fails, log it and move on
+            log.debug(f'Cleaning nav slugs failed: {e}')
+        return (
+            model.Session.query(NavigationalSlug)
+            .filter(NavigationalSlug.on_slug(slug))
+            .first()
+        )
     return (
         model.Session.query(DatastoreSlug).filter(DatastoreSlug.on_slug(slug)).first()
     )
@@ -206,7 +263,7 @@ def reserve_slug(
     if resource_ids_and_versions is not None:
         assert isinstance(resource_ids_and_versions, dict)
 
-    slug = resolve_slug(reserved_pretty_slug)
+    slug = resolve_slug(reserved_pretty_slug, False)
     if slug is not None:
         # a slug with this reserved pretty slug already exists
         return slug
@@ -250,3 +307,28 @@ def reserve_slug(
                     f'The query parameters are already associated with a '
                     f'different slug: {slug.get_slug_string()}'
                 )
+
+
+def clean_nav_slugs(before=None):
+    """
+    Delete old/expired navigational slugs.
+
+    :param before: a datetime object; slugs created before this time will be removed
+                   (defaults to 2 days ago)
+    :return: the number of deleted slugs
+    """
+    if before is None:
+        before = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+
+    old_slugs = (
+        model.Session.query(NavigationalSlug)
+        .filter(NavigationalSlug.created < before)
+        .all()
+    )
+    slug_count = len(old_slugs)
+    for slug in old_slugs:
+        slug.delete()
+
+    model.Session.commit()
+
+    return slug_count

--- a/ckanext/versioned_datastore/lib/query/slugs.py
+++ b/ckanext/versioned_datastore/lib/query/slugs.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import IntegrityError
 from .schema import get_latest_query_version, hash_query
 from .schema import validate_query
 from .slug_words import list_one, list_two, list_three
-from .utils import get_available_datastore_resources
+from .utils import get_available_datastore_resources, get_resources_and_versions
 from ...model.slugs import DatastoreSlug
 
 
@@ -95,12 +95,9 @@ def create_slug(
     # only store valid queries!
     validate_query(query, query_version)
 
-    if resource_ids:
-        resource_ids = list(get_available_datastore_resources(context, resource_ids))
-        if not resource_ids:
-            raise toolkit.ValidationError(
-                u"The requested resources aren't accessible to this user"
-            )
+    resource_ids, resource_ids_and_versions = get_resources_and_versions(
+        resource_ids, resource_ids_and_versions, version
+    )
 
     query_hash = generate_query_hash(
         query, query_version, version, resource_ids, resource_ids_and_versions

--- a/ckanext/versioned_datastore/lib/query/utils.py
+++ b/ckanext/versioned_datastore/lib/query/utils.py
@@ -223,3 +223,51 @@ def find_searched_resources(search, resource_ids):
         for bucket in result.aggs.to_dict()['indexes']['buckets']
         if bucket['doc_count'] > 0
     ]
+
+
+def get_resources_and_versions(
+    resource_ids=None, resource_ids_and_versions=None, version=None
+):
+    """
+    Get a list of resource ids and a dict of resource ids and versions from either, e.g.
+    get the list of resource ids from a resource id and version dict.
+
+    :param resource_ids: a list of resource ids
+    :param resource_ids_and_versions: a dict of resource id: resource version
+    :param version: a datestamp used as a default version for resources without a version
+    :return: a tuple of resource_ids, resource_ids_and_versions
+    """
+
+    if resource_ids_and_versions is None:
+        resource_ids_and_versions = {}
+    else:
+        # use the resource_ids_and_versions dict first over the resource_ids and version params
+        resource_ids = list(resource_ids_and_versions.keys())
+
+    # figure out which resources should be searched
+    resource_ids = list(get_available_datastore_resources({}, resource_ids))
+    if not resource_ids:
+        raise toolkit.ValidationError(
+            "The requested resources aren't accessible to this user"
+        )
+
+    rounded_resource_ids_and_versions = {}
+    # see if a version was provided; we'll use this if a resource id we're searching doesn't
+    # have a directly assigned version (i.e. it was absent from the resource_ids_and_versions
+    # dict, or that parameter wasn't provided)
+    if version is None:
+        version = to_timestamp(datetime.now())
+    for resource_id in resource_ids:
+        # try to get the target version from the passed resource_ids_and_versions dict, but if
+        # it's not in there, default to the version variable
+        target_version = resource_ids_and_versions.get(resource_id, version)
+        index = prefix_resource(resource_id)
+        # round the version down to ensure we search the exact version requested
+        rounded_version = common.SEARCH_HELPER.get_rounded_versions(
+            [index], target_version
+        )[index]
+        if rounded_version is not None:
+            # resource ids without a rounded version are skipped
+            rounded_resource_ids_and_versions[resource_id] = rounded_version
+
+    return resource_ids, rounded_resource_ids_and_versions

--- a/ckanext/versioned_datastore/lib/query/utils.py
+++ b/ckanext/versioned_datastore/lib/query/utils.py
@@ -257,7 +257,7 @@ def get_resources_and_versions(
         )
 
     unavailable_resource_ids = [
-        rid for rid in resource_ids if rid not in available_resource_ids
+        rid for rid in resource_ids or [] if rid not in available_resource_ids
     ]
     non_datastore_resources = []
 

--- a/ckanext/versioned_datastore/lib/query/utils.py
+++ b/ckanext/versioned_datastore/lib/query/utils.py
@@ -1,12 +1,12 @@
 from copy import copy
+from datetime import datetime
+
+from elasticsearch_dsl import Search, MultiSearch
+from splitgill.search import create_version_query, create_index_specific_version_filter
+from splitgill.utils import to_timestamp
 
 from ckan import model
 from ckan.plugins import toolkit
-from datetime import datetime
-from splitgill.search import create_version_query, create_index_specific_version_filter
-from splitgill.utils import to_timestamp
-from elasticsearch_dsl import Search, MultiSearch
-
 from .. import common
 from ..datastore_utils import prefix_resource, get_last_after, trim_index_name
 
@@ -226,7 +226,10 @@ def find_searched_resources(search, resource_ids):
 
 
 def get_resources_and_versions(
-    resource_ids=None, resource_ids_and_versions=None, version=None
+    resource_ids=None,
+    resource_ids_and_versions=None,
+    version=None,
+    allow_non_datastore=False,
 ):
     """
     Get a list of resource ids and a dict of resource ids and versions from either, e.g.
@@ -235,6 +238,8 @@ def get_resources_and_versions(
     :param resource_ids: a list of resource ids
     :param resource_ids_and_versions: a dict of resource id: resource version
     :param version: a datestamp used as a default version for resources without a version
+    :param allow_non_datastore: allow non datastore resources to be included (will be
+                                returned with common.NON_DATASTORE_VERSION)
     :return: a tuple of resource_ids, resource_ids_and_versions
     """
 
@@ -244,12 +249,27 @@ def get_resources_and_versions(
         # use the resource_ids_and_versions dict first over the resource_ids and version params
         resource_ids = list(resource_ids_and_versions.keys())
 
-    # figure out which resources should be searched
-    resource_ids = list(get_available_datastore_resources({}, resource_ids))
-    if not resource_ids:
+    # first see what's available from the datastore
+    available_resource_ids = list(get_available_datastore_resources({}, resource_ids))
+    if (not available_resource_ids) and (not allow_non_datastore):
         raise toolkit.ValidationError(
             "The requested resources aren't accessible to this user"
         )
+
+    unavailable_resource_ids = [
+        rid for rid in resource_ids if rid not in available_resource_ids
+    ]
+    non_datastore_resources = []
+
+    if allow_non_datastore:
+        resource_show = toolkit.get_action('resource_show')
+        for resource_id in unavailable_resource_ids:
+            resource = resource_show({}, {'id': resource_id})
+            # if we get nothing back there's probably an access issue; if it's a
+            # datastore resource something went wrong earlier
+            if resource and not resource['datastore_active']:
+                available_resource_ids.append(resource_id)
+                non_datastore_resources.append(resource_id)
 
     rounded_resource_ids_and_versions = {}
     # see if a version was provided; we'll use this if a resource id we're searching doesn't
@@ -257,7 +277,12 @@ def get_resources_and_versions(
     # dict, or that parameter wasn't provided)
     if version is None:
         version = to_timestamp(datetime.now())
-    for resource_id in resource_ids:
+    for resource_id in available_resource_ids:
+        if resource_id in non_datastore_resources:
+            rounded_resource_ids_and_versions[
+                resource_id
+            ] = common.NON_DATASTORE_VERSION
+            continue
         # try to get the target version from the passed resource_ids_and_versions dict, but if
         # it's not in there, default to the version variable
         target_version = resource_ids_and_versions.get(resource_id, version)
@@ -270,4 +295,4 @@ def get_resources_and_versions(
             # resource ids without a rounded version are skipped
             rounded_resource_ids_and_versions[resource_id] = rounded_version
 
-    return resource_ids, rounded_resource_ids_and_versions
+    return available_resource_ids, rounded_resource_ids_and_versions

--- a/ckanext/versioned_datastore/logic/actions/meta/schema.py
+++ b/ckanext/versioned_datastore/logic/actions/meta/schema.py
@@ -169,6 +169,7 @@ def datastore_create_slug():
         'resource_ids': [ignore_missing, list_of_strings()],
         'resource_ids_and_versions': [ignore_missing, json_validator],
         'pretty_slug': [ignore_missing, boolean_validator],
+        'nav_slug': [ignore_missing, boolean_validator],
     }
 
 

--- a/ckanext/versioned_datastore/logic/actions/multisearch.py
+++ b/ckanext/versioned_datastore/logic/actions/multisearch.py
@@ -2,15 +2,16 @@ from collections import defaultdict
 from datetime import datetime
 
 import jsonschema
-from ckan.plugins import toolkit, PluginImplementations, plugin_loaded
-from splitgill.utils import to_timestamp
-from elasticsearch_dsl import MultiSearch, A
-
-from .meta import help, schema
 from ckantools.decorators import action
 from ckantools.timer import Timer
+from elasticsearch_dsl import MultiSearch, A
+from splitgill.utils import to_timestamp
+
+from ckan.plugins import toolkit, PluginImplementations, plugin_loaded
+from .meta import help, schema
 from ...interfaces import IVersionedDatastore
 from ...lib import common
+from ...lib.basic_query.utils import convert_to_multisearch
 from ...lib.datastore_utils import (
     prefix_resource,
     unprefix_index,
@@ -231,6 +232,10 @@ def datastore_create_slug(
     """
     if query is None:
         query = {}
+    if query_version and query_version.lower().startswith('v0'):
+        # this is an old/basic query so we need to convert it first
+        query = convert_to_multisearch(query)
+        query_version = None
     if query_version is None:
         query_version = get_latest_query_version()
 

--- a/ckanext/versioned_datastore/logic/actions/multisearch.py
+++ b/ckanext/versioned_datastore/logic/actions/multisearch.py
@@ -295,6 +295,9 @@ def datastore_resolve_slug(slug):
             )
         }
         result['created'] = resolved.created.isoformat()
+        if result.get('query_version') == 'v0':
+            result['query'] = convert_to_multisearch(result['query'])
+            result['query_version'] = get_latest_query_version()
         return result
 
     # then check if it's a query DOI
@@ -304,9 +307,15 @@ def datastore_resolve_slug(slug):
 
         resolved = model.Session.query(QueryDOI).filter(QueryDOI.doi == slug).first()
         if resolved:
+            if resolved.query_version == 'v0':
+                query = convert_to_multisearch(resolved.query)
+                query_version = get_latest_query_version()
+            else:
+                query = resolved.query
+                query_version = resolved.query_version
             return {
-                'query': resolved.query,
-                'query_version': resolved.query_version,
+                'query': query,
+                'query_version': query_version,
                 'version': resolved.requested_version,
                 'resource_ids': list(resolved.resources_and_versions.keys()),
                 'resource_ids_and_versions': resolved.resources_and_versions,

--- a/ckanext/versioned_datastore/migration/versioned_datastore/versions/526b12c69d55_add_navigational_slugs.py
+++ b/ckanext/versioned_datastore/migration/versioned_datastore/versions/526b12c69d55_add_navigational_slugs.py
@@ -1,0 +1,46 @@
+"""
+Add navigational slugs.
+
+Revision ID: 526b12c69d55
+Revises: 19a61e5b669f
+Create Date: 2023-06-07 16:25:59.090795
+"""
+from datetime import datetime as dt
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.declarative import declarative_base
+
+# revision identifiers, used by Alembic.
+revision = '526b12c69d55'
+down_revision = '19a61e5b669f'
+branch_labels = None
+depends_on = None
+
+Base = declarative_base()
+
+
+def make_uuid():
+    return str(uuid4())
+
+
+class NavigationalSlug(Base):
+    __tablename__ = 'versioned_datastore_navigational_slugs'
+
+    id = sa.Column(sa.UnicodeText, primary_key=True, default=make_uuid)
+    query_hash = sa.Column(sa.UnicodeText, nullable=False, index=True, unique=True)
+    query = sa.Column(JSONB, nullable=False)
+    resource_ids_and_versions = sa.Column(JSONB, nullable=False, default=dict)
+    created = sa.Column(sa.DateTime, nullable=False, default=dt.utcnow)
+
+
+def upgrade():
+    bind = op.get_bind()
+    NavigationalSlug.__table__.create(bind)
+
+
+def downgrade():
+    bind = op.get_bind()
+    NavigationalSlug.__table__.drop(bind)

--- a/ckanext/versioned_datastore/plugin.py
+++ b/ckanext/versioned_datastore/plugin.py
@@ -68,6 +68,7 @@ class VersionedSearchPlugin(SingletonPlugin):
             'pretty_print_json': helpers.pretty_print_json,
             'get_version_date': helpers.get_version_date,
             'latest_item_version': helpers.latest_item_version,
+            'nav_slug': helpers.nav_slug,
         }
 
     # IResourceController

--- a/ckanext/versioned_datastore/theme/assets/less/download-popup.less
+++ b/ckanext/versioned_datastore/theme/assets/less/download-popup.less
@@ -1,0 +1,42 @@
+.vds-download-popup {
+  & p {
+    word-break: keep-all;
+  }
+
+  & .form-group {
+    margin-bottom: 20px;
+
+    &:not(:last-child) {
+      padding-bottom: 10px;
+      border-bottom: 1px solid #dddddd;
+    }
+  }
+
+  & .form-row,
+  & .privacy-warning {
+    padding: 5px;
+  }
+
+  & .full-width-input {
+    width: 100%;
+  }
+
+  & select {
+    height: 1em;
+  }
+
+  & input[type='text'] {
+    padding: 5px;
+    border: 1px solid #c3c3c3;
+    border-radius: 5px;
+  }
+
+  & .privacy-warning {
+    border: none;
+  }
+
+  // this should be in the main ckan css, but just in case
+  & .hidden {
+    display: none !important;
+  }
+}

--- a/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
+++ b/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
@@ -12,6 +12,7 @@ ckan.module('versioned_datastore_download-button', function ($) {
       // process options into searchOptions and templateOptions
       this.templateOptions = {
         multiResource: true,
+        datastore: true,
       };
       this.searchOptions = {};
 
@@ -36,8 +37,6 @@ ckan.module('versioned_datastore_download-button', function ($) {
         if (this.options.non_datastore) {
           this.options.query = {};
           this.templateOptions.datastore = false;
-        } else {
-          this.templateOptions.datastore = true;
         }
 
         // query can either be an object or 'FROM URL'

--- a/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
+++ b/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
@@ -1,0 +1,174 @@
+ckan.module('versioned_datastore_download-button', function ($) {
+  return {
+    initialize: function () {
+      // use the same 'this' object in all _on*() functions in this module
+      $.proxyAll(this, /_on/);
+      // do the same for _toggleLoading
+      $.proxy(this._toggleLoading, /_toggle/);
+
+      // process options
+      this.options.resources = this.options.resources.split(',');
+
+      // get the icon and its classes so we can turn it into a spinner while the snippet is loading
+      this.icon = this.$('#vds-download-button-icon');
+      this.iconClass = this.icon[0].className;
+
+      // set up a template options object
+      this.templateOptions = {
+        multiResource: this.options.resources.length > 1,
+      };
+
+      // get a slug for this search; it doesn't really matter if this fails, but it's nice
+      let slugData = {
+        resource_ids: this.options.resources,
+      };
+      this.slug = null;
+      this._toggleLoading(true);
+      this.sandbox.client.call(
+        'POST',
+        'datastore_create_slug',
+        slugData,
+        (response) => {
+          if (response.success) {
+            this.slug = response.result.slug;
+          }
+          this.templateOptions['searchUrl'] =
+            this.sandbox.client.endpoint + '/search/' + (this.slug || '');
+          this._toggleLoading(false);
+        },
+      );
+
+      // set up event handlers
+      this.el.on('click', this._onClick);
+      this.el.on('shown.bs.popover', this._onShowPopover);
+    },
+
+    _snippetReceived: false,
+
+    _onReceiveSnippet: function (html) {
+      this.el.popover({
+        html: true,
+        sanitize: false,
+        content: html,
+        placement: 'bottom',
+        viewport: {
+          selector: 'body',
+          padding: 20,
+        },
+        trigger: 'manual', // it has to be manual so we can hide/cancel from inside it
+      });
+      this.el.popover('show');
+      this._toggleLoading(false);
+    },
+
+    _onReceiveSnippetError: function (error) {
+      this._flashError();
+    },
+
+    _onClick: function (event) {
+      if (!this._snippetReceived) {
+        this._toggleLoading(true);
+        this.sandbox.client.getTemplate(
+          'download_popup.html',
+          this.templateOptions,
+          this._onReceiveSnippet,
+          this._onReceiveSnippetError,
+        );
+        this._snippetReceived = true;
+      } else {
+        this.el.popover('toggle');
+      }
+    },
+
+    _onShowPopover: function (event) {
+      // every time we show the popover it creates a new instance with a new id, so we
+      // have to set up all the listeners again
+
+      let popoverId = this.el.attr('aria-describedby');
+      let popover = $(`#${popoverId}`);
+      let popoverForm = popover.find('form');
+
+      // hide it when the cancel button is clicked
+      popoverForm.on('reset', () => {
+        this.el.popover('hide');
+      });
+
+      // hide/show the email group when user changes notif type
+      const notifierSelect = popoverForm.find('#vds-dl-notifier');
+      notifierSelect.on('change', () => {
+        let emailGroup = popoverForm.find('#vds-dl-email-group');
+        if (notifierSelect.val() === 'email') {
+          emailGroup.removeClass('hidden');
+        } else {
+          emailGroup.addClass('hidden');
+        }
+      });
+
+      popoverForm.on('submit', (e) => {
+        e.preventDefault();
+        let formData = {
+          query: {
+            resource_ids: this.options.resources,
+          },
+        };
+        popoverForm.serializeArray().forEach((i) => {
+          let nameParts = i.name.split('.');
+          nameParts.reduce((parentContainer, part, ix) => {
+            if (!Object.keys(parentContainer).includes(part)) {
+              // this retains a reference to formData, so we're just setting nested
+              // properties on that
+              parentContainer[part] =
+                ix === nameParts.length - 1 ? i.value : {};
+            }
+            return parentContainer[part];
+          }, formData);
+        });
+        this._toggleLoading(true);
+        this.sandbox.client.call(
+          'POST',
+          'datastore_queue_download',
+          formData,
+          (response) => {
+            if (response.success) {
+              popoverForm.addClass('hidden');
+              popover
+                .find('#vds-dl-status-link')
+                .attr(
+                  'href',
+                  this.sandbox.client.endpoint +
+                    '/status/download/' +
+                    response.result.download_id,
+                );
+              popover.find('#vds-dl-post-submit').removeClass('hidden');
+            } else {
+              this._flashError();
+            }
+            this._toggleLoading(false);
+          },
+        );
+      });
+    },
+
+    _toggleLoading: function (isLoading) {
+      this.icon.removeClass();
+      this.icon.addClass(isLoading ? 'fas fa-spinner fa-spin' : this.iconClass);
+    },
+
+    _flashError: function (message) {
+      message =
+        message ||
+        'Unable to download at the moment. Try again later, contact ' +
+          'us, or try downloading from the search page.';
+      let errorMessages = $('.flash-messages .vds-dl-error');
+      if (errorMessages.length === 0) {
+        $('.flash-messages').append(
+          '<div class="alert alert-error vds-dl-error">' + message + '</div>',
+        );
+      }
+    },
+
+    _removeErrors: function () {
+      $('.flash-messages .vds-dl-error').remove();
+    },
+  };
+});

--- a/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
+++ b/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
@@ -8,6 +8,8 @@ ckan.module('versioned_datastore_download-button', function ($) {
 
       // process options
       this.options.resources = this.options.resources.split(',');
+      this.options.query =
+        typeof this.options.query === 'object' ? this.options.query : {};
 
       // get the icon and its classes so we can turn it into a spinner while the snippet is loading
       this.icon = this.$('#vds-download-button-icon');
@@ -19,7 +21,8 @@ ckan.module('versioned_datastore_download-button', function ($) {
       };
 
       // get a slug for this search; it doesn't really matter if this fails, but it's nice
-      let slugData = {
+      this.searchQuery = {
+        query: this.options.query,
         resource_ids: this.options.resources,
       };
       this.slug = null;
@@ -27,7 +30,7 @@ ckan.module('versioned_datastore_download-button', function ($) {
       this.sandbox.client.call(
         'POST',
         'datastore_create_slug',
-        slugData,
+        this.searchQuery,
         (response) => {
           if (response.success) {
             this.slug = response.result.slug;
@@ -106,11 +109,7 @@ ckan.module('versioned_datastore_download-button', function ($) {
 
       popoverForm.on('submit', (e) => {
         e.preventDefault();
-        let formData = {
-          query: {
-            resource_ids: this.options.resources,
-          },
-        };
+        let formData = { query: { ...this.searchQuery } };
         popoverForm.serializeArray().forEach((i) => {
           let nameParts = i.name.split('.');
           nameParts.reduce((parentContainer, part, ix) => {
@@ -123,6 +122,8 @@ ckan.module('versioned_datastore_download-button', function ($) {
             return parentContainer[part];
           }, formData);
         });
+        console.log(this.searchQuery);
+        console.log(formData);
         this._toggleLoading(true);
         this.sandbox.client.call(
           'POST',

--- a/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
+++ b/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
@@ -156,10 +156,21 @@ ckan.module('versioned_datastore_download-button', function ($) {
           let nameParts = i.name.split('.');
           nameParts.reduce((parentContainer, part, ix) => {
             if (!Object.keys(parentContainer).includes(part)) {
+              let val;
+              switch (i.value) {
+                case 'on':
+                  val = true;
+                  break;
+                case 'off':
+                  val = false;
+                  break;
+                default:
+                  val = i.value;
+                  break;
+              }
               // this retains a reference to formData, so we're just setting nested
               // properties on that
-              parentContainer[part] =
-                ix === nameParts.length - 1 ? i.value : {};
+              parentContainer[part] = ix === nameParts.length - 1 ? val : {};
             }
             return parentContainer[part];
           }, formData);

--- a/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
+++ b/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
@@ -62,6 +62,11 @@ ckan.module('versioned_datastore_download-button', function ($) {
       // set up event handlers
       this.el.on('click', this._onClick);
       this.el.on('shown.bs.popover', this._onShowPopover);
+      this.sandbox.subscribe('vds_dl_popover_shown', this._onEvent);
+    },
+
+    teardown: function () {
+      this.sandbox.unsubscribe('vds_dl_popover_shown', this._onEvent);
     },
 
     _snippetReceived: false,
@@ -102,6 +107,9 @@ ckan.module('versioned_datastore_download-button', function ($) {
     },
 
     _onShowPopover: function (event) {
+      // emit/publish event for other download buttons to listen to
+      this.sandbox.publish('vds_dl_popover_shown', this.el);
+
       // every time we show the popover it creates a new instance with a new id, so we
       // have to set up all the listeners again
 
@@ -210,6 +218,12 @@ ckan.module('versioned_datastore_download-button', function ($) {
           console.error(error);
         },
       );
+    },
+
+    _onEvent: function (button) {
+      if (button !== this.el) {
+        this.el.popover('hide');
+      }
     },
 
     _setLoading: function (isLoading) {

--- a/ckanext/versioned_datastore/theme/assets/webassets.yml
+++ b/ckanext/versioned_datastore/theme/assets/webassets.yml
@@ -28,3 +28,15 @@ slugerator:
   filters: less
   contents:
     - less/slugerator.less
+
+download-button-js:
+  output: ckanext-versioned-datastore/%(version)s_download-button.js
+  filters: rjsmin
+  contents:
+    - scripts/modules/download-button.js
+
+download-button-css:
+  output: ckanext-versioned-datastore/%(version)s_download-button.css
+  filters: less
+  contents:
+    - less/download-popup.less

--- a/ckanext/versioned_datastore/theme/assets/webassets.yml
+++ b/ckanext/versioned_datastore/theme/assets/webassets.yml
@@ -32,6 +32,10 @@ slugerator:
 download-button-js:
   output: ckanext-versioned-datastore/%(version)s_download-button.js
   filters: rjsmin
+  extra:
+    preload:
+      - vendor/jquery
+      - base/main
   contents:
     - scripts/modules/download-button.js
 

--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -1,5 +1,6 @@
 <div class="vds-download-popup">
     <form>
+        {% if datastore == 'true' %}
         <p><small>More advanced download options can be found on the <a
             href="{{ searchUrl }}" target="_blank" id="vds-dl-search-link">search page</a>.</small>
         </p>
@@ -27,6 +28,7 @@
                 </div>
             </div>
         </div>
+        {% endif %}
 
         <div class="form-group">
             <div class="form-row">

--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -1,7 +1,7 @@
 <div class="vds-download-popup">
     <form>
         <p><small>More advanced download options can be found on the <a
-            href="{{ searchUrl }}" target="_blank">search page</a>.</small>
+            href="{{ searchUrl }}" target="_blank" id="vds-dl-search-link">search page</a>.</small>
         </p>
         <div class="form-group">
             <div class="form-row"><label for="vds-dl-format">File format</label>

--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -1,7 +1,7 @@
 <div class="vds-download-popup">
     <form>
         <p><small>More advanced download options can be found on the <a
-            href="{{ searchUrl }}">search page</a>.</small>
+            href="{{ searchUrl }}" target="_blank">search page</a>.</small>
         </p>
         <div class="form-group">
             <div class="form-row"><label for="vds-dl-format">File format</label>

--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -1,0 +1,84 @@
+<div class="vds-download-popup">
+    <form>
+        <p><small>More advanced download options can be found on the <a
+            href="{{ searchUrl }}">search page</a>.</small>
+        </p>
+        <div class="form-group">
+            <div class="form-row"><label for="vds-dl-format">File format</label>
+                <select id="vds-dl-format" class="full-width-input" name="file.format">
+                    <option value="csv">CSV/TSV</option>
+                    <option value="dwc">Darwin Core</option>
+                    <option value="xlsx">Excel (XLSX)</option>
+                    <option value="json">JSON</option>
+                </select>
+            </div>
+
+            <div class="form-row">
+                {% if multiResource == 'true' %}
+                <div>
+                    <label for="vds-dl-sep">One file per resource</label>
+                    <input id="vds-dl-sep" type="checkbox" name="file.separate_files">
+                </div>
+                {% endif %}
+                <div>
+                    <label for="vds-dl-empty">Skip empty columns</label>
+                    <input id="vds-dl-empty" type="checkbox"
+                           name="file.ignore_empty_fields">
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <div class="form-row">
+                <label for="vds-dl-notifier">Notifications</label>
+                <p><small>Should we notify you when your download is ready?</small></p>
+                <select id="vds-dl-notifier" class="full-width-input"
+                        name="notifier.type">
+                    <option value="email">
+                        Email me
+                    </option>
+                    <option value="none">
+                        I'll check the download status manually
+                    </option>
+                </select>
+            </div>
+            <div class="form-row" id="vds-dl-email-group">
+                <label for="vds-dl-email">Email address(es)</label>
+                <input id="vds-dl-email" type="text"
+                       placeholder="data@nhm.ac.uk"
+                       class="full-width-input" name="notifier.type_args.emails">
+                <p>
+                    <small>Multiple email addresses can be added as a comma-separated
+                           list.</small>
+                </p>
+            </div>
+        </div>
+
+        <div class="privacy-warning">
+            <p><i>Data Protection</i></p>
+            <p>
+                The Natural History Museum will use your personal data in accordance
+                with data protection legislation to process your requests. For more
+                information please read our <a href="/privacy">privacy notice</a>.
+            </p>
+        </div>
+
+        <div>
+            <button type="submit" class="btn btn-primary" id="vds-dl-submit">
+                <i class="fas fa-download"></i> {{ _('Submit') }}
+            </button>
+            <button type="reset" class="btn btn-warning" id="vds-dl-cancel">
+                <i class="fas fa-times"></i> {{ _('Cancel') }}
+            </button>
+        </div>
+    </form>
+
+    <div id="vds-dl-post-submit" class="hidden">
+        <p>Your download has been queued. You can follow its progress at the link
+           below:</p>
+        <a href="#" class="btn btn-primary" id="vds-dl-status-link" target="_blank"><i
+            class="fas fa-hourglass-half"></i>
+            Download status
+        </a>
+    </div>
+</div>

--- a/ckanext/versioned_datastore/theme/templates/status/download.html
+++ b/ckanext/versioned_datastore/theme/templates/status/download.html
@@ -137,7 +137,9 @@
                     <td>
                         <dl>
                             <dt>Total</dt>
-                            <dd>{{ download_request.core_record.total or _('processing') }}</dd>
+                            {% if download_request.core_record.total is not None %}
+                            <dd>{{ download_request.core_record.total }}</dd>
+                            {% endif %}
                             {% if download_request.core_record.resource_totals %}
                             {% for res_id, res in resources.items() %}
                             {% if download_request.core_record.resource_totals[res_id] > 0 %}

--- a/ckanext/versioned_datastore/theme/templates/versioned_datastore/snippets/download_button.html
+++ b/ckanext/versioned_datastore/theme/templates/versioned_datastore/snippets/download_button.html
@@ -1,7 +1,8 @@
 {#
     Parameters:
         resources: comma-separated list of resource IDs
-        query: search query to apply; defaults to {} (no query, selects all records)
+        query: search query to apply, or 'FROM URL' to extract from current url; defaults
+               to {} (no query, selects all records)
         slug_or_doi: a slug or doi for a saved search (overrides other settings)
         icon_class: class for the button icon (eg. fas fa-download etc.)
         label: text for the button (eg. _('Download'))
@@ -13,8 +14,9 @@
 
 <button class="btn btn-primary vds-download-button"
         data-module="versioned_datastore_download-button"
-        data-module-resources="{{ resources }}"
-        data-module-query="{{ query }}"
-        data-module-slug_or_doi="{{ slug_or_doi }}">
+        {% if resources %}data-module-resources="{{ resources }}"{% endif %}
+        {% if query %}data-module-query="{{ query }}"{% endif %}
+        {% if slug_or_doi %}data-module-slug_or_doi="{{ slug_or_doi }}"{% endif %}
+>
     <i id="vds-download-button-icon" class="{{ icon_class }}"></i> {{ label }}
 </button>

--- a/ckanext/versioned_datastore/theme/templates/versioned_datastore/snippets/download_button.html
+++ b/ckanext/versioned_datastore/theme/templates/versioned_datastore/snippets/download_button.html
@@ -1,0 +1,16 @@
+{#
+    Parameters:
+        resources: comma-separated list of resource IDs;
+        icon_class: class for the button icon (eg. fas fa-download etc.)
+        label: text for the button (eg. _('Download'))
+#}
+
+{% asset 'ckanext-versioned-datastore/download-button-js' %}
+{% asset 'ckanext-versioned-datastore/download-button-css' %}
+
+
+<button class="btn btn-primary vds-download-button"
+        data-module="versioned_datastore_download-button"
+        data-module-resources="{{ resources }}">
+    <i id="vds-download-button-icon" class="{{ icon_class }}"></i> {{ label }}
+</button>

--- a/ckanext/versioned_datastore/theme/templates/versioned_datastore/snippets/download_button.html
+++ b/ckanext/versioned_datastore/theme/templates/versioned_datastore/snippets/download_button.html
@@ -4,6 +4,8 @@
         query: search query to apply, or 'FROM URL' to extract from current url; defaults
                to {} (no query, selects all records)
         slug_or_doi: a slug or doi for a saved search (overrides other settings)
+        non_datastore: if this is a non-datastore resource (default false, i.e. it is a
+                       datastore resource)
         icon_class: class for the button icon (eg. fas fa-download etc.)
         label: text for the button (eg. _('Download'))
 #}
@@ -17,6 +19,7 @@
         {% if resources %}data-module-resources="{{ resources }}"{% endif %}
         {% if query %}data-module-query="{{ query }}"{% endif %}
         {% if slug_or_doi %}data-module-slug_or_doi="{{ slug_or_doi }}"{% endif %}
+        {% if non_datastore %}data-module-non_datastore{% endif %}
 >
     <i id="vds-download-button-icon" class="{{ icon_class }}"></i> {{ label }}
 </button>

--- a/ckanext/versioned_datastore/theme/templates/versioned_datastore/snippets/download_button.html
+++ b/ckanext/versioned_datastore/theme/templates/versioned_datastore/snippets/download_button.html
@@ -3,6 +3,7 @@
         resources: comma-separated list of resource IDs;
         icon_class: class for the button icon (eg. fas fa-download etc.)
         label: text for the button (eg. _('Download'))
+        query: search query to apply; defaults to {} (no query, selects all records)
 #}
 
 {% asset 'ckanext-versioned-datastore/download-button-js' %}
@@ -11,6 +12,7 @@
 
 <button class="btn btn-primary vds-download-button"
         data-module="versioned_datastore_download-button"
-        data-module-resources="{{ resources }}">
+        data-module-resources="{{ resources }}"
+        data-module-query="{{ query }}">
     <i id="vds-download-button-icon" class="{{ icon_class }}"></i> {{ label }}
 </button>

--- a/ckanext/versioned_datastore/theme/templates/versioned_datastore/snippets/download_button.html
+++ b/ckanext/versioned_datastore/theme/templates/versioned_datastore/snippets/download_button.html
@@ -1,9 +1,10 @@
 {#
     Parameters:
-        resources: comma-separated list of resource IDs;
+        resources: comma-separated list of resource IDs
+        query: search query to apply; defaults to {} (no query, selects all records)
+        slug_or_doi: a slug or doi for a saved search (overrides other settings)
         icon_class: class for the button icon (eg. fas fa-download etc.)
         label: text for the button (eg. _('Download'))
-        query: search query to apply; defaults to {} (no query, selects all records)
 #}
 
 {% asset 'ckanext-versioned-datastore/download-button-js' %}
@@ -13,6 +14,7 @@
 <button class="btn btn-primary vds-download-button"
         data-module="versioned_datastore_download-button"
         data-module-resources="{{ resources }}"
-        data-module-query="{{ query }}">
+        data-module-query="{{ query }}"
+        data-module-slug_or_doi="{{ slug_or_doi }}">
     <i id="vds-download-button-icon" class="{{ icon_class }}"></i> {{ label }}
 </button>

--- a/test.ini
+++ b/test.ini
@@ -9,6 +9,8 @@ port = 5000
 # them from an IDE like PyCharm which will copy the code into /opt/project/ and run it from there
 use = config:/base/src/ckan/test-core.ini
 
+ckan.storage_path = /base/data/ckan/storage
+
 # the hosts referenced here resolve to the other docker containers configured in docker-compose.yml
 sqlalchemy.url = postgresql://ckan:password@db/ckan
 ckan.datastore.write_url = postgresql://ckan:password@db/datastore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def with_versioned_datastore_tables(reset_db):
     tables = [
         stats.import_stats_table,
         slugs.datastore_slugs_table,
+        slugs.navigational_slugs_table,
         details.datastore_resource_details_table,
         downloads.datastore_downloads_core_files_table,
         downloads.datastore_downloads_derivative_files_table,

--- a/tests/helpers/patches.py
+++ b/tests/helpers/patches.py
@@ -53,7 +53,7 @@ def elasticsearch_client():
 def get_available_resources(resource_ids=None):
     resource_ids = resource_ids or ['test-resource-id']
     return patch(
-        'ckanext.versioned_datastore.lib.downloads.query.get_available_datastore_resources',
+        'ckanext.versioned_datastore.lib.query.utils.get_available_datastore_resources',
         return_value=resource_ids,
     )
 


### PR DESCRIPTION
[ckanpackager](https://github.com/NaturalHistoryMuseum/ckanpackager) and [ckanext-ckanpackager](https://github.com/NaturalHistoryMuseum/ckanext-ckanpackager) are being deprecated. This extension already had some overlap with the functionality, but these changes should (hopefully) replace it entirely.

Notable:
- added navigational slugs for carrying query information from page to page concisely; they expire after 2 days
- new download button that can be included as a snippet in other extensions
- helper for converting old/basic queries to new multisearch format (this is probably quite flaky)
- added ability to download non-datastore resources (a bit out of scope in a datastore extension _but_ it's a fairly small part of the download system and it needed to be in the same place)