### PR TITLE
fix: catch null values in xlsx files better

### DIFF
--- a/ckanext/versioned_datastore/lib/importing/ingestion/readers.py
+++ b/ckanext/versioned_datastore/lib/importing/ingestion/readers.py
@@ -292,7 +292,7 @@ class XLSXReader(ResourceReader):
                     else:
                         raise Exception('_id not int')
                 # ignore empty cells
-                elif isinstance(cell, EmptyCell):
+                elif isinstance(cell, EmptyCell) or cell.value is None:
                     continue
                 else:
                     # convert everything else to unicode


### PR DESCRIPTION
We check for empty cells but we can also check if the cell value is None too so we might as well.