### PR TITLE
Fix notifier bugs, add email validation

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -135,9 +135,6 @@ class DownloadRunManager:
         """
         Run the download process.
         """
-        self.notifier.notify_start()
-        self.request.update_status(DownloadRequest.state_initial)
-
         try:
             # refresh the db objects because they were probably retrieved in a
             # different session (the __init__ is run by the main ckan process,
@@ -145,6 +142,9 @@ class DownloadRunManager:
             self.request = DownloadRequest.get(self.request.id)
             self.core_record = CoreFileRecord.get(self.core_record.id)
             self.derivative_record = DerivativeFileRecord.get(self.derivative_record.id)
+
+            self.notifier.notify_start()
+            self.request.update_status(DownloadRequest.state_initial)
 
             # generate core file if needed
             # technically we don't need core files if the format is 'raw', but we'll

--- a/ckanext/versioned_datastore/lib/downloads/notifiers/__init__.py
+++ b/ckanext/versioned_datastore/lib/downloads/notifiers/__init__.py
@@ -1,6 +1,15 @@
 from .email import EmailNotifier
 from .webhook import WebhookNotifier
 from .null import NullNotifier
-
+from ckan.plugins import toolkit
 
 notifiers = [EmailNotifier, WebhookNotifier, NullNotifier]
+
+
+def validate_notifier_args(notifier_type, notifier_type_args):
+    try:
+        notifier = next(n for n in notifiers if n.name == notifier_type)
+    except StopIteration:
+        raise toolkit.Invalid('Invalid notifier type.')
+
+    return notifier.validate_args(notifier_type_args)

--- a/ckanext/versioned_datastore/lib/downloads/notifiers/base.py
+++ b/ckanext/versioned_datastore/lib/downloads/notifiers/base.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
-from ckan.plugins import toolkit, PluginImplementations
 from jinja2 import Template
 
+from ckan.plugins import toolkit, PluginImplementations
 from ....interfaces import IVersionedDatastoreDownloads
 from ....model.downloads import DownloadRequest
 
@@ -111,3 +111,7 @@ class BaseNotifier(metaclass=ABCMeta):
     @abstractmethod
     def notify_error(self):
         raise NotImplemented
+
+    @classmethod
+    def validate_args(cls, type_args):
+        return True

--- a/ckanext/versioned_datastore/lib/downloads/notifiers/email.py
+++ b/ckanext/versioned_datastore/lib/downloads/notifiers/email.py
@@ -1,5 +1,7 @@
-from ckan.lib import mailer
+import re
 
+from ckan.lib import mailer
+from ckan.plugins import toolkit
 from .base import BaseNotifier
 
 default_html_body = '''
@@ -59,3 +61,15 @@ class EmailNotifier(BaseNotifier):
                 body=body,
                 body_html=body_html,
             )
+
+    @classmethod
+    def validate_args(cls, type_args):
+        emails = type_args.get('emails')
+        if not emails:
+            raise toolkit.Invalid('Email address must be provided.')
+        emails = emails if isinstance(emails, list) else [emails]
+        email_rgx = re.compile(r'(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)')
+        for e in emails:
+            if not email_rgx.fullmatch(e):
+                raise toolkit.Invalid('Email address appears to be invalid.')
+        return True

--- a/ckanext/versioned_datastore/lib/downloads/notifiers/webhook.py
+++ b/ckanext/versioned_datastore/lib/downloads/notifiers/webhook.py
@@ -35,3 +35,10 @@ class WebhookNotifier(BaseNotifier):
         context = self.template_context()
         params = {self.url_param: context['status_page'], self.text_param: text}
         requests.request(request_method, self.url, params=params)
+
+    @classmethod
+    def validate_args(cls, type_args):
+        url = type_args.get('url')
+        if not url:
+            raise toolkit.Invalid('URL must be provided')
+        return True

--- a/ckanext/versioned_datastore/logic/actions/downloads.py
+++ b/ckanext/versioned_datastore/logic/actions/downloads.py
@@ -5,6 +5,7 @@ from .meta import help, schema
 from .meta.arg_objects import ServerArgs, NotifierArgs, QueryArgs, DerivativeArgs
 from ...lib.downloads.download import DownloadRunManager
 from ...model.downloads import DownloadRequest
+from ...lib.downloads.notifiers import validate_notifier_args
 
 
 @action(schema.datastore_queue_download(), help.datastore_queue_download)
@@ -17,6 +18,8 @@ def datastore_queue_download(
 ):
     server = server or ServerArgs(**ServerArgs.defaults)
     notifier = notifier or NotifierArgs(**NotifierArgs.defaults)
+
+    validate_notifier_args(notifier.type, notifier.type_args)
 
     if server.custom_filename:
         # check if admin

--- a/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
+++ b/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
@@ -126,10 +126,13 @@ ckan.module('versioned_datastore_download-button', function ($) {
       const notifierSelect = this.popoverForm.find('#vds-dl-notifier');
       notifierSelect.on('change', () => {
         let emailGroup = this.popoverForm.find('#vds-dl-email-group');
+        let emailBox = this.popoverForm.find('#vds-dl-email');
         if (notifierSelect.val() === 'email') {
           emailGroup.removeClass('hidden');
+          emailBox.attr('required', true);
         } else {
           emailGroup.addClass('hidden');
+          emailBox.removeAttr('required');
         }
       });
 

--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -46,7 +46,7 @@
             </div>
             <div class="form-row" id="vds-dl-email-group">
                 <label for="vds-dl-email">Email address(es)</label>
-                <input id="vds-dl-email" type="text"
+                <input id="vds-dl-email" type="email" required
                        placeholder="data@nhm.ac.uk"
                        class="full-width-input" name="notifier.type_args.emails">
                 <p>


### PR DESCRIPTION
Users were able to (and were doing so repeatedly) submit the popup form with incorrect or blank email addresses. The download failed immediately because it wasn't able to send the "starting" notification, but the status in the database didn't change from "initiated".

Three things done in this PR:
- stop users being able to submit the popup form with bad or blank emails
- add email and webhook validation so if they do still manage to submit a request, it doesn't make it to the download queue and they get a sensible error message
- added the notifier call to the try-except section so if it fails, we know about it