### PR TITLE
Remove the text saying multiple emails are allowed

### DIFF
--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -45,14 +45,10 @@
                 </select>
             </div>
             <div class="form-row" id="vds-dl-email-group">
-                <label for="vds-dl-email">Email address(es)</label>
+                <label for="vds-dl-email">Email address</label>
                 <input id="vds-dl-email" type="email" required
                        placeholder="data@nhm.ac.uk"
                        class="full-width-input" name="notifier.type_args.emails">
-                <p>
-                    <small>Multiple email addresses can be added as a comma-separated
-                           list.</small>
-                </p>
             </div>
         </div>
 


### PR DESCRIPTION
Multiple emails are allowed by the API, but I never implemented a way of getting them into a list from the textbox.