### PR TITLE
Allow users to specify a custom title for DwC downloads

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/derivatives/dwc/generator.py
+++ b/ckanext/versioned_datastore/lib/downloads/derivatives/dwc/generator.py
@@ -29,12 +29,14 @@ class DwcDerivativeGenerator(BaseDerivativeGenerator):
         extension_names=None,
         extension_map=None,
         id_field='_id',
+        eml_title=None,
         **format_args,
     ):
         super(DwcDerivativeGenerator, self).__init__(
             output_dir, fields, query, resource_id, **format_args
         )
         self._id_field = id_field
+        self._eml_title = eml_title
         self._build_dir_name = uuid4().hex
         self._build_dir = os.path.join(self.output_dir, self._build_dir_name)
         os.mkdir(self._build_dir)
@@ -323,7 +325,7 @@ class DwcDerivativeGenerator(BaseDerivativeGenerator):
         dataset_metadata = OrderedDict(
             {
                 'alternateIdentifier': [self._query.hash],
-                'title': f'Query on {site_name}',
+                'title': self._eml_title or f'Query on {site_name}',
                 'creator': [org],
                 'metadataProvider': [org],
                 'pubDate': dt.now().strftime('%Y-%m-%d'),

--- a/ckanext/versioned_datastore/routes/__init__.py
+++ b/ckanext/versioned_datastore/routes/__init__.py
@@ -9,5 +9,6 @@ from . import datastore, search, downloads, status
 
 blueprints = [datastore.blueprint, search.blueprint, status.blueprint]
 
-if toolkit.config.get('DEBUG', False):
+is_debug = toolkit.asbool(toolkit.config.get('debug', toolkit.config.get('DEBUG')))
+if is_debug:
     blueprints.append(downloads.blueprint)


### PR DESCRIPTION
Adding `eml_title` as a `format_arg` replaces the "Query on [site title]".

This PR also includes a bonus fix for the debug direct download route, which wasn't being loaded because there are multiple `debug` variables.