### PR TITLE
Add another download hook, EML bugfix

### DIFF
--- a/ckanext/versioned_datastore/interfaces.py
+++ b/ckanext/versioned_datastore/interfaces.py
@@ -362,6 +362,7 @@ class IVersionedDatastoreDownloads(interfaces.Interface):
         """
         Hook allowing other extensions to modify args before any search is run or files
         generated.
+        FIXME: this should be renamed to download_before_init or similar
 
         :param query_args: a QueryArgs object
         :param derivative_args: a DerivativeArgs object
@@ -371,6 +372,16 @@ class IVersionedDatastoreDownloads(interfaces.Interface):
                  notifier_args)
         """
         return query_args, derivative_args, server_args, notifier_args
+
+    def download_after_init(self, query):
+        """
+        Hook notifying that the downloader and associated objects (e.g. the query) have
+        been initialised. Does not allow modification; purely for notification purposes.
+
+        :param query: the query for this download
+        :return: None
+        """
+        return
 
     def download_modify_manifest(self, manifest, request):
         """

--- a/ckanext/versioned_datastore/lib/downloads/derivatives/dwc/generator.py
+++ b/ckanext/versioned_datastore/lib/downloads/derivatives/dwc/generator.py
@@ -293,8 +293,8 @@ class DwcDerivativeGenerator(BaseDerivativeGenerator):
         packages = [package_show({}, {'id': r['package_id']}) for r in resources]
 
         # useful bools
-        single_resource = len(resources) == 0
-        single_package = len(packages) == 0
+        single_resource = len(resources) == 1
+        single_package = len(packages) == 1
         empty_query = self._query.query == {}
 
         # define some site variables

--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -102,6 +102,9 @@ class DownloadRunManager:
 
         self._temp = []
 
+        for plugin in PluginImplementations(IVersionedDatastoreDownloads):
+            plugin.download_after_init(self.request)
+
     @property
     def derivative_hash(self):
         """

--- a/tests/integration/downloads/test_downloads.py
+++ b/tests/integration/downloads/test_downloads.py
@@ -539,6 +539,9 @@ class ModifyArgsPlugin:
     def download_after_run(self, request):
         return
 
+    def download_after_init(self, request):
+        return
+
 
 class ModifyManifestPlugin:
     def download_before_run(self, *args):
@@ -549,4 +552,7 @@ class ModifyManifestPlugin:
         return manifest
 
     def download_after_run(self, request):
+        return
+
+    def download_after_init(self, request):
         return

--- a/tests/unit/lib/downloads/test_downloads_runmanager.py
+++ b/tests/unit/lib/downloads/test_downloads_runmanager.py
@@ -77,3 +77,6 @@ class MockPlugin:
     ):
         derivative_args.format = 'dwc'
         return query_args, derivative_args, server_args, notifier_args
+
+    def download_after_init(self, request):
+        return


### PR DESCRIPTION
- minor EML bugfix: fixes the very silly bug where I used 0 instead of 1 when checking the length of the resource/package lists
- adds a `download_after_init` hook that runs at the end of the `DownloadRunManager` setup; intended to be used to generate the query DOI (via ckanext-query-dois) earlier in the process, rather than at the end when the manifest is being written.