### PR TITLE
Increase performance in datastore_get_resource_versions action

### DIFF
--- a/ckanext/versioned_datastore/logic/actions/extras.py
+++ b/ckanext/versioned_datastore/logic/actions/extras.py
@@ -70,7 +70,7 @@ def datastore_get_resource_versions(
     # batch up the searches and get better performance (there could be 1000s of
     # versions to count after all). This variable simply defines how many searches to do
     # in each msearch batch
-    multisearch_chunk_size = 10
+    multisearch_chunk_size = 100
 
     for details_chunk in chunk_iterator(counts, multisearch_chunk_size):
         multisearch = MultiSearch(using=common.ES_CLIENT, index=index_name)

--- a/ckanext/versioned_datastore/logic/actions/extras.py
+++ b/ckanext/versioned_datastore/logic/actions/extras.py
@@ -46,14 +46,14 @@ def datastore_get_resource_versions(
     """
     Retrieves all the versions of the given resource when under the given search. Note
     that the schema used for this action is the same as the datastore_search schema. The
-    return is a dict including the version timestamp, the number of records modified in
-    the version and the total records at the version.
+    return is a list of dicts each of which includes the version timestamp, the number
+    of records modified in the version and the total records at the version.
 
     :param resource_id: the id of the resource to examine
     :param context: the context dict from the action call
     :param data_dict: the data_dict from the action call
     :param original_data_dict: the data_dict before it was validated
-    :return:
+    :return: a list of dicts
     """
     original_data_dict, data_dict, version, search = create_search(
         context, data_dict, original_data_dict

--- a/ckanext/versioned_datastore/logic/actions/extras.py
+++ b/ckanext/versioned_datastore/logic/actions/extras.py
@@ -60,14 +60,14 @@ def datastore_get_resource_versions(
     )
     index_name = prefix_resource(resource_id)
 
-    data = common.SEARCH_HELPER.get_index_version_counts(index_name, search=search)
+    counts = common.SEARCH_HELPER.get_index_version_counts(index_name, search=search)
 
     search = search.using(common.ES_CLIENT).index(index_name)[0:0]
-    for result in data:
+    for result in counts:
         version = result['version']
         count = search.filter(create_version_query(version)).count()
         result['count'] = count
-    return data
+    return counts
 
 
 @action(


### PR DESCRIPTION
`datastore_get_resource_versions` is slow and it's taking longer than NGINX is willing to wait so we're getting timeouts. Increasing the NGINX proxy timeout is possible but it's not the best solution, making the action faster is better 🙂 

To get it to go faster, the action has been switched from using individual count requests to the elasticsearch cluster to `msearch` batches. Tested on staging and seems to be a big improvement.


Fixes https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/issues/130