### PR TITLE
Hotfix: ignore `_id` field in extension rows

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/derivatives/dwc/generator.py
+++ b/ckanext/versioned_datastore/lib/downloads/derivatives/dwc/generator.py
@@ -197,7 +197,7 @@ class DwcDerivativeGenerator(BaseDerivativeGenerator):
                 def _extract_ext(subdict):
                     props = {'_id': record_id}
                     for ek, ev in subdict.items():
-                        if ek in ext_props:
+                        if ek in ext_props and ek != '_id':
                             props[ek] = ev
                     return props
 


### PR DESCRIPTION
- the core file and any extensions need a common field/identifier to join on
- we use `_id` because every record has an `_id` field
- the multimedia extension pulls its data from `associatedMedia`, which _also_ has its own separate `_id` (the IRN of the image)
- this was overwriting the record `_id`, so the identifiers did not match up
- the media `_id` is fairly useless for external viewers, so ignoring it when processing records for DwC export is the quickest and easiest way to fix this issue