### PR TITLE
Set default resource totals to 0

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/download.py
+++ b/ckanext/versioned_datastore/lib/downloads/download.py
@@ -270,7 +270,7 @@ class DownloadRunManager:
             and v != common.NON_DATASTORE_VERSION
         }
 
-        resource_totals = {k: None for k in self.core_record.resource_ids_and_versions}
+        resource_totals = {k: 0 for k in self.core_record.resource_ids_and_versions}
         field_counts = {k: None for k in self.core_record.resource_ids_and_versions}
 
         # get info for resources that weren't just generated first, so we know if they


### PR DESCRIPTION
Causes issues with stats (and also just doesn't make much sense) if some counts are integers and others are nulls.