### PR TITLE
fix: ensure the workbook is closed if something goes wrong during the write call

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/derivatives/xlsx.py
+++ b/ckanext/versioned_datastore/lib/downloads/derivatives/xlsx.py
@@ -29,8 +29,12 @@ class XlsxDerivativeGenerator(BaseDerivativeGenerator):
         super(XlsxDerivativeGenerator, self).setup()
 
     def finalise(self):
-        self.workbook.save(self.file_paths['main'])
-        self.workbook.close()
+        try:
+            self.workbook.save(self.file_paths['main'])
+        finally:
+            # if something goes wrong when trying to save the workbook, make sure to
+            # close the workbook before raising the error
+            self.workbook.close()
         super(XlsxDerivativeGenerator, self).finalise()
 
     def _write(self, record):


### PR DESCRIPTION
I'm not 100% sure this catches the problem as I couldn't recreate it locally (it must be an error at a very specific point or something?) but this has a decent chance of fixing the problem of a temporary workbook being left around in /tmp after we've finished/errored the download.

Closes: #118