### PR TITLE
Skip empty extension rows

### DIFF
--- a/ckanext/versioned_datastore/lib/downloads/derivatives/dwc/generator.py
+++ b/ckanext/versioned_datastore/lib/downloads/derivatives/dwc/generator.py
@@ -205,6 +205,9 @@ class DwcDerivativeGenerator(BaseDerivativeGenerator):
                     ext_extracted = [_extract_ext(x) for x in v]
                 elif isinstance(v, dict):
                     ext_extracted = [_extract_ext(v)]
+                elif v is None:
+                    # skip if empty
+                    ext_extracted = []
                 else:
                     ext_extracted = [_extract_ext({k: v})]
                 ext[extension_map[k]] = ext_extracted


### PR DESCRIPTION
Not a major code or API change, but this does change output files; DwC extension files (e.g. multimedia.csv) will now only output rows for records with relevant data, even if ignore_empty_fields is false.

Closes: #138