### PR TITLE
fix: sort on version rather than date modified

### DIFF
--- a/ckanext/versioned_datastore/logic/actions/multisearch.py
+++ b/ckanext/versioned_datastore/logic/actions/multisearch.py
@@ -126,7 +126,7 @@ def datastore_multisearch(
     # of the modified date, id of the record and the index it's in so that we get a unique sort
     search = search.sort(
         # not all indexes have a modified field so we need to provide the unmapped_type option
-        {'data.modified': {'order': 'desc', 'unmapped_type': 'date'}},
+        {'meta.version': 'desc'},
         {'data._id': 'desc'},
         {'_index': 'desc'},
     )


### PR DESCRIPTION
date modified was causing issues with some datasets; es would generate a huge integer instead of the actual modified date, then wouldn't be able to handle that huge integer. using version achieves basically the same thing, though is slightly less precise.