### PR TITLE
Fix some query errors before running

### DIFF
--- a/ckanext/versioned_datastore/lib/query/schema.py
+++ b/ckanext/versioned_datastore/lib/query/schema.py
@@ -98,6 +98,20 @@ def hash_query(query, version):
         return schemas[version].hash(query)
 
 
+def normalise_query(query, version):
+    """
+    Corrects some (small) common query errors, e.g. removing empty groups.
+
+    :param query: the query dict
+    :param version: the query version
+    :return: the corrected/normalised query
+    """
+    if version not in schemas:
+        raise InvalidQuerySchemaVersionError(version)
+    else:
+        return schemas[version].normalise(query)
+
+
 def load_core_schema(version):
     """
     Given a query schema version, loads the schema from the schema_base_path directory.
@@ -155,3 +169,12 @@ class Schema(object):
         :return: a string hex digest
         """
         pass
+
+    def normalise(self, query):
+        """
+        Corrects some (small) common query errors, e.g. removing empty groups.
+
+        :param query: the query dict
+        :return: the corrected/normalised query dict
+        """
+        return query

--- a/ckanext/versioned_datastore/lib/query/utils.py
+++ b/ckanext/versioned_datastore/lib/query/utils.py
@@ -324,3 +324,32 @@ def convert_small_or_groups(query):
     query['filters'] = _convert(query['filters'])[0]
 
     return query
+
+
+def remove_empty_groups(query):
+    """
+    Remove empty groups from filter list.
+
+    :param query: a multisearch query dict
+    :return: the query with a processed filter dict, if applicable
+    """
+    if 'filters' not in query:
+        return query
+
+    def _convert(*filters):
+        items = []
+        for term_or_group in filters:
+            k, v = list(term_or_group.items())[0]
+            if k not in ['and', 'or', 'not']:
+                items.append(term_or_group)
+            elif len(v) > 0:
+                items.append({k: _convert(*v)})
+        return items
+
+    processed_filters = _convert(query['filters'])
+    if len(processed_filters) == 0:
+        del query['filters']
+    else:
+        query['filters'] = processed_filters[0]
+
+    return query

--- a/ckanext/versioned_datastore/lib/query/v1_0_0.py
+++ b/ckanext/versioned_datastore/lib/query/v1_0_0.py
@@ -9,6 +9,7 @@ from elasticsearch_dsl.query import Bool, Q
 
 from .schema import Schema, load_core_schema, schema_base_path
 from ..datastore_utils import prefix_field
+from .utils import convert_small_or_groups, remove_empty_groups
 
 
 class v1_0_0Schema(Schema):
@@ -63,6 +64,17 @@ class v1_0_0Schema(Schema):
         search = self.add_search(query, search)
         search = self.add_filters(query, search)
         return search
+
+    def normalise(self, query):
+        """
+        Corrects some (small) common query errors, e.g. removing empty groups.
+
+        :param query: the query dict
+        :return: the corrected/normalised query dict
+        """
+        query = convert_small_or_groups(query)
+        query = remove_empty_groups(query)
+        return query
 
     def add_search(self, query, search):
         """

--- a/ckanext/versioned_datastore/logic/actions/multisearch.py
+++ b/ckanext/versioned_datastore/logic/actions/multisearch.py
@@ -42,6 +42,7 @@ from ...lib.query.utils import (
     calculate_after,
     find_searched_resources,
     convert_small_or_groups,
+    remove_empty_groups,
 )
 
 
@@ -99,6 +100,7 @@ def datastore_multisearch(
 
     # try to correct some small errors
     query = convert_small_or_groups(query)
+    query = remove_empty_groups(query)
 
     try:
         # validate and translate the query into an elasticsearch-dsl Search object

--- a/ckanext/versioned_datastore/logic/actions/multisearch.py
+++ b/ckanext/versioned_datastore/logic/actions/multisearch.py
@@ -33,6 +33,7 @@ from ...lib.query.schema import (
     validate_query,
     translate_query,
     hash_query,
+    normalise_query,
 )
 from ...lib.query.slugs import create_slug, resolve_slug, create_nav_slug
 from ...lib.query.utils import (
@@ -41,8 +42,6 @@ from ...lib.query.utils import (
     determine_version_filter,
     calculate_after,
     find_searched_resources,
-    convert_small_or_groups,
-    remove_empty_groups,
 )
 
 
@@ -98,9 +97,7 @@ def datastore_multisearch(
 
     timer = Timer()
 
-    # try to correct some small errors
-    query = convert_small_or_groups(query)
-    query = remove_empty_groups(query)
+    query = normalise_query(query, query_version)
 
     try:
         # validate and translate the query into an elasticsearch-dsl Search object
@@ -430,6 +427,8 @@ def datastore_guess_fields(
         set(g.lower() for g in ignore_groups) if ignore_groups is not None else set()
     )
 
+    query = normalise_query(query, query_version)
+
     try:
         # validate and translate the query into an elasticsearch-dsl Search object
         validate_query(query, query_version)
@@ -526,6 +525,8 @@ def datastore_value_autocomplete(
     # limit the size so that it is between 1 and 500
     size = max(1, min(size, 500))
 
+    query = normalise_query(query, query_version)
+
     try:
         # validate and translate the query into an elasticsearch-dsl Search object
         validate_query(query, query_version)
@@ -607,6 +608,8 @@ def datastore_hash_query(query=None, query_version=None):
     if query_version is None:
         query_version = get_latest_query_version()
 
+    query = normalise_query(query, query_version)
+
     try:
         validate_query(query, query_version)
     except (jsonschema.ValidationError, InvalidQuerySchemaVersionError) as e:
@@ -673,6 +676,8 @@ def datastore_multisearch_counts(
         query = {}
     if query_version is None:
         query_version = get_latest_query_version()
+
+    query = normalise_query(query, query_version)
 
     try:
         # validate and translate the query into an elasticsearch-dsl Search object

--- a/ckanext/versioned_datastore/logic/actions/multisearch.py
+++ b/ckanext/versioned_datastore/logic/actions/multisearch.py
@@ -41,6 +41,7 @@ from ...lib.query.utils import (
     determine_version_filter,
     calculate_after,
     find_searched_resources,
+    convert_small_or_groups,
 )
 
 
@@ -95,6 +96,9 @@ def datastore_multisearch(
     size = max(0, min(size, 1000))
 
     timer = Timer()
+
+    # try to correct some small errors
+    query = convert_small_or_groups(query)
 
     try:
         # validate and translate the query into an elasticsearch-dsl Search object

--- a/tests/unit/lib/query/test_query_utils.py
+++ b/tests/unit/lib/query/test_query_utils.py
@@ -1,0 +1,54 @@
+from ckanext.versioned_datastore.lib.query.utils import (
+    convert_small_or_groups,
+    remove_empty_groups,
+)
+
+
+class TestQueryUtils(object):
+    def test_converts_single_item_or_group(self):
+        test_query = {
+            'filters': {'or': [{'string_equals': {'fields': ['x'], 'value': 'y'}}]}
+        }
+        expected_query = {
+            'filters': {'and': [{'string_equals': {'fields': ['x'], 'value': 'y'}}]}
+        }
+        output_query = convert_small_or_groups(test_query)
+        assert output_query == expected_query
+
+    def test_converts_nested_single_item_or_group(self):
+        test_query = {'filters': {'and': [{'or': [{'exists': {'fields': ['x']}}]}]}}
+        expected_query = {
+            'filters': {'and': [{'and': [{'exists': {'fields': ['x']}}]}]}
+        }
+        output_query = convert_small_or_groups(test_query)
+        assert output_query == expected_query
+
+    def test_does_not_convert_multi_item_or_group(self):
+        test_query = {
+            'filters': {
+                'or': [{'exists': {'fields': ['x']}}, {'exists': {'fields': ['y']}}]
+            }
+        }
+        output_query = convert_small_or_groups(test_query)
+        assert output_query == test_query
+
+    def test_does_not_convert_empty_or_group(self):
+        test_query = {'filters': {'or': []}}
+        output_query = convert_small_or_groups(test_query)
+        assert output_query == test_query
+
+    def test_removes_empty_groups(self):
+        test_query = {
+            'filters': {'and': [{'or': []}, {'not': [{'exists': {'fields': ['x']}}]}]}
+        }
+        expected_query = {
+            'filters': {'and': [{'not': [{'exists': {'fields': ['x']}}]}]}
+        }
+        output_query = remove_empty_groups(test_query)
+        assert output_query == expected_query
+
+    def test_removes_filters_if_root_empty(self):
+        test_query = {'filters': {'and': []}}
+        expected_query = {}
+        output_query = remove_empty_groups(test_query)
+        assert output_query == expected_query


### PR DESCRIPTION
Convert OR groups with one item to AND, and remove empty groups. These changes don't alter the meaning of the query, but they will prevent some common errors.

Also includes \~unit tests\~ (ooooh).

Closes #157 