### PR TITLE
Status patches

### DIFF
--- a/ckanext/versioned_datastore/lib/datastore_utils.py
+++ b/ckanext/versioned_datastore/lib/datastore_utils.py
@@ -290,30 +290,16 @@ def is_ingestible(resource):
 
 def get_queue_length(queue_name):
     """
-    This is a *very* hacky way to get the length of a queue, including anything already
+    This will only get the pending jobs in a queue, not any jobs that are currently
     processing.
 
     :param queue_name: the name of the queue to check, e.g. 'download'
     :return: length of queue as int
     """
-    # because only pending jobs are counted, not active/running, if you add to the queue
-    # and job_list can't see it, the queue was empty; if it can, something else is
-    # already running.
-    def _temp_job():
-        time.sleep(1)
-
-    job = toolkit.enqueue_job(
-        _temp_job,
-        queue=queue_name,
-        title=f'{queue_name} queue status test',
-        rq_kwargs={'ttl': '1s'},
-    )
 
     queued_jobs = toolkit.get_action('job_list')(
         {'ignore_auth': True}, {'queues': [queue_name]}
     )
-
-    job.delete()
 
     return len(queued_jobs)
 

--- a/ckanext/versioned_datastore/plugin.py
+++ b/ckanext/versioned_datastore/plugin.py
@@ -188,12 +188,10 @@ class VersionedSearchPlugin(SingletonPlugin):
                 'label': toolkit._('Downloads'),
                 'value': queued_downloads,
                 'group': toolkit._('Queues'),
-                'help': toolkit._(
-                    'Number of downloads either currently processing or waiting in the queue'
-                ),
+                'help': toolkit._('Number of downloads waiting in the queue'),
                 'state': 'good'
-                if queued_downloads == 0
-                else ('ok' if queued_downloads < 3 else 'bad'),
+                if queued_downloads < 2
+                else ('ok' if queued_downloads < 4 else 'bad'),
             }
         )
 
@@ -204,12 +202,10 @@ class VersionedSearchPlugin(SingletonPlugin):
                 'label': toolkit._('Imports'),
                 'value': queued_imports,
                 'group': toolkit._('Queues'),
-                'help': toolkit._(
-                    'Number of import jobs either currently processing or waiting in the queue'
-                ),
+                'help': toolkit._('Number of import jobs waiting in the queue'),
                 'state': 'good'
-                if queued_imports == 0
-                else ('ok' if queued_imports < 3 else 'bad'),
+                if queued_imports < 2
+                else ('ok' if queued_imports < 4 else 'bad'),
             }
         )
 


### PR DESCRIPTION
- removes the hacky method that adds temporary jobs to queues in order to get an accurate queue length; it now isn't as accurate but it doesn't break everything, so that's probably better
- increases the tolerance for queue lengths; i.e. it will only reach "amber" alert when there are 2 queued items (not including currently processing) and "bad" when there are 4