### PR TITLE
Update docker command for test runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build images
-        run: docker-compose build
+        run: docker compose build
 
       - name: Run tests
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: docker-compose run -e COVERALLS_REPO_TOKEN ckan bash /opt/scripts/run-tests.sh -c ckanext.versioned_datastore
+        run: docker compose run -e COVERALLS_REPO_TOKEN ckan bash /opt/scripts/run-tests.sh -c ckanext.versioned_datastore

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ To run the tests against ckan 2.9.x on Python3:
 
 1. Build the required images:
    ```shell
-   docker-compose build
+   docker compose build
    ```
 
 2. Then run the tests.
@@ -259,7 +259,7 @@ To run the tests against ckan 2.9.x on Python3:
    configuration, so you should only need to rebuild the ckan image if you change the extension's
    dependencies.
    ```shell
-   docker-compose run ckan
+   docker compose run ckan
    ```
 
 <!--testing-end-->


### PR DESCRIPTION
docker-compose is deprecated and tests were no longer running.