### PR TITLE
Update splitgill to v3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8"
 ]
 dependencies = [
-    "splitgill==3.0.1",
+    "splitgill==3.1.0",
     "importlib-resources",
     "backports.csv==1.0.6",
     "cchardet==2.1.4",


### PR DESCRIPTION
Update vds to new version of Splitgill which fixes the [index op generation bug](https://github.com/NaturalHistoryMuseum/splitgill/issues/34).