### PR TITLE
Recreate a raw elasticsearch search action

### DIFF
--- a/ckanext/versioned_datastore/logic/basic/action.py
+++ b/ckanext/versioned_datastore/logic/basic/action.py
@@ -56,7 +56,6 @@ def vds_basic_query(
         "records": response.data,
         "facets": format_facets(response.aggs),
         "fields": get_fields(resource_id, request.query.version),
-        "raw_fields": {},
         "after": response.next_after,
     }
 

--- a/ckanext/versioned_datastore/logic/basic/utils.py
+++ b/ckanext/versioned_datastore/logic/basic/utils.py
@@ -159,7 +159,7 @@ def infer_type(
 
     # check for dates first, then booleans, then numbers, and then default to string
     for parsed_type in (ParsedType.DATE, ParsedType.BOOLEAN, ParsedType.NUMBER):
-        if parsed_field.type_counts[parsed_type] / parsed_field.count > threshold:
+        if parsed_field.type_counts[parsed_type] / parsed_field.count >= threshold:
             # just so happens that the recline types match the ParsedType names
             return parsed_type.name.lower()
     return 'string'

--- a/ckanext/versioned_datastore/logic/basic/utils.py
+++ b/ckanext/versioned_datastore/logic/basic/utils.py
@@ -1,6 +1,7 @@
 from operator import itemgetter
-from typing import List, Optional
+from typing import Dict, List, Optional
 
+from splitgill.indexing.fields import DataField, ParsedField, ParsedType
 from splitgill.search import keyword
 
 from ckanext.versioned_datastore.lib.importing.details import get_details_at
@@ -123,6 +124,47 @@ def format_facets(aggs: dict) -> dict:
     return facets
 
 
+def infer_type(
+    data_field: DataField, parsed_fields: Dict[str, ParsedField], threshold: float = 0.8
+) -> str:
+    """
+    Infers the type of each of the given data fields, using the parsed fields to
+    determine what type to assign. A type is assigned to a field if more than the
+    threshold percentage of values in the field are of the parsed type.
+
+    This function uses the parsed types instead of the data types for three reasons:
+      - often the field data types are just strings, so we'd need to use the parsed
+        types anyway to get a non-string type
+      - the response to the get_fields function where this function is called is
+        typically used in a search result and therefore the fields response may be used
+        to create another search in which case the parsed types would have to be used
+        as you can't search using the data types
+      - there is no date field data type, whereas there is a date field parsed type
+
+    In most cases, the parsed type returned by this function will match the data type of
+    the field's values.
+
+    :param data_field: the data field to infer for
+    :param parsed_fields: a dict of parsed paths to parsed fields
+    :param threshold: a threshold determining the percentage of the values in the field
+                      which must be of the parsed type to be inferred as it
+                      (default: 0.8, i.e., 80%)
+    :return: the name of the inferred type (one of string, number, date, boolean)
+    """
+    parsed_field = parsed_fields.get(data_field.parsed_path)
+
+    # this should only ever happen for fields which are always nested objects
+    if not parsed_field:
+        return 'object'
+
+    # check for dates first, then booleans, then numbers, and then default to string
+    for parsed_type in (ParsedType.DATE, ParsedType.BOOLEAN, ParsedType.NUMBER):
+        if parsed_field.type_counts[parsed_type] / parsed_field.count > threshold:
+            # just so happens that the recline types match the ParsedType names
+            return parsed_type.name.lower()
+    return 'string'
+
+
 def get_fields(resource_id: str, version: Optional[int] = None) -> List[dict]:
     """
     Given a resource id, returns the fields that existed at the given version. If the
@@ -150,6 +192,7 @@ def get_fields(resource_id: str, version: Optional[int] = None) -> List[dict]:
     """
     database = get_database(resource_id)
     data_fields = database.get_data_fields(version)
+    parsed_fields = {field.path: field for field in database.get_parsed_fields(version)}
 
     fields = []
     seen = {'_id'}
@@ -159,7 +202,7 @@ def get_fields(resource_id: str, version: Optional[int] = None) -> List[dict]:
             continue
         field_repr = {
             'id': field.parsed_path,
-            'type': 'string',
+            'type': infer_type(field, parsed_fields),
             'sortable': True,
         }
         if field.children:

--- a/ckanext/versioned_datastore/logic/multi/auth.py
+++ b/ckanext/versioned_datastore/logic/multi/auth.py
@@ -1,43 +1,50 @@
+from ckan.authz import is_sysadmin
 from ckantools.decorators import auth
 
 
 @auth(anon=True)
 def vds_multi_query(context, data_dict) -> dict:
     # allow access to everyone
-    return {"success": True}
+    return {'success': True}
 
 
 @auth(anon=True)
 def vds_multi_count(context, data_dict) -> dict:
     # allow access to everyone
-    return {"success": True}
+    return {'success': True}
 
 
 @auth(anon=True)
 def vds_multi_autocomplete_value(context, data_dict) -> dict:
     # allow access to everyone
-    return {"success": True}
+    return {'success': True}
 
 
 @auth(anon=True)
 def vds_multi_autocomplete_field(context, data_dict) -> dict:
     # allow access to everyone
-    return {"success": True}
+    return {'success': True}
 
 
 @auth(anon=True)
 def vds_multi_hash(context, data_dict) -> dict:
     # allow access to everyone
-    return {"success": True}
+    return {'success': True}
 
 
 @auth(anon=True)
 def vds_multi_fields(context, data_dict) -> dict:
     # allow access to everyone
-    return {"success": True}
+    return {'success': True}
 
 
 @auth(anon=True)
 def vds_multi_stats(context, data_dict) -> dict:
     # allow access to everyone
-    return {"success": True}
+    return {'success': True}
+
+
+@auth()
+def vds_multi_direct(context, data_dict):
+    # only allow for admins
+    return {'success': is_sysadmin(context.get('user'))}

--- a/ckanext/versioned_datastore/logic/multi/helptext.py
+++ b/ckanext/versioned_datastore/logic/multi/helptext.py
@@ -1,7 +1,8 @@
-vds_multi_query = ""
-vds_multi_count = ""
-vds_multi_autocomplete_value = ""
-vds_multi_autocomplete_field = ""
-vds_multi_hash = ""
-vds_multi_fields = ""
-vds_multi_stats = ""
+vds_multi_query = ''
+vds_multi_count = ''
+vds_multi_autocomplete_value = ''
+vds_multi_autocomplete_field = ''
+vds_multi_hash = ''
+vds_multi_fields = ''
+vds_multi_stats = ''
+vds_multi_direct = ''

--- a/ckanext/versioned_datastore/logic/multi/schema.py
+++ b/ckanext/versioned_datastore/logic/multi/schema.py
@@ -71,3 +71,11 @@ def vds_multi_stats() -> dict:
         'missing': [ignore_missing, float],
         'field': [not_empty, str],
     }
+
+
+def vds_multi_direct() -> dict:
+    return {
+        'resource_ids': [validate_datastore_resource_ids],
+        'search': [ignore_missing, json_validator],
+        'version': [ignore_missing, str],
+    }

--- a/tests/unit/logic/basic/test_utils.py
+++ b/tests/unit/logic/basic/test_utils.py
@@ -72,7 +72,7 @@ def test_get_fields():
     assert fields == [
         {'id': '_id', 'type': 'string'},
         {'id': 'field1', 'type': 'string', 'sortable': True},
-        {'id': 'field2', 'type': 'string', 'sortable': True},
+        {'id': 'field2', 'type': 'number', 'sortable': True},
         {'id': 'field3', 'type': 'array', 'sortable': False},
     ]
 

--- a/tests/unit/logic/basic/test_utils.py
+++ b/tests/unit/logic/basic/test_utils.py
@@ -1,4 +1,7 @@
+from collections import Counter
+
 import pytest
+from splitgill.indexing.fields import DataField, ParsedField, ParsedType
 from splitgill.model import Record
 
 from ckanext.versioned_datastore.lib.importing.options import (
@@ -11,6 +14,7 @@ from ckanext.versioned_datastore.logic.basic.utils import (
     find_version,
     format_facets,
     get_fields,
+    infer_type,
     make_request,
 )
 
@@ -75,6 +79,37 @@ def test_get_fields():
         {'id': 'field2', 'type': 'number', 'sortable': True},
         {'id': 'field3', 'type': 'array', 'sortable': False},
     ]
+
+
+class TestInferType:
+    def test_non_parsed(self):
+        df = DataField('test')
+        pfs = {}
+        assert infer_type(df, pfs) == 'object'
+
+    def test_threshold(self):
+        df = DataField('test')
+        pf = ParsedField('test', count=10, type_counts=Counter({ParsedType.NUMBER: 5}))
+        pfs = {'test': pf}
+        assert infer_type(df, pfs, threshold=0.9) == 'string'
+        assert infer_type(df, pfs, threshold=0.3) == 'number'
+        assert infer_type(df, pfs, threshold=0.5) == 'number'
+
+    def test_order_of_preference(self):
+        df = DataField('test')
+        pf = ParsedField('test', count=10, type_counts=Counter())
+        pfs = {'test': pf}
+
+        assert infer_type(df, pfs) == 'string'
+
+        pf.type_counts[ParsedType.NUMBER] = 10
+        assert infer_type(df, pfs) == 'number'
+
+        pf.type_counts[ParsedType.BOOLEAN] = 10
+        assert infer_type(df, pfs) == 'boolean'
+
+        pf.type_counts[ParsedType.DATE] = 10
+        assert infer_type(df, pfs) == 'date'
 
 
 class TestFindVersion:


### PR DESCRIPTION
We used to have `datastore_search_raw` which allowed users to query elasticsearch directly using normal elasticsearch queries. This is not great so it was removed in v6, but it does have a use, so it's been readded with the restriction that it's only available to admin users. This means if you want to use it via the API you need to provide the appropriate authentication, but it does still allow other extensions to use it by passing ignore_auth in their context dict.

The readded action is called `vds_multi_direct`.