### PR TITLE
Query DOI versions

### DIFF
--- a/ckanext/versioned_datastore/logic/slug/action.py
+++ b/ckanext/versioned_datastore/logic/slug/action.py
@@ -114,10 +114,17 @@ def vds_slug_resolve(slug: str):
             else:
                 query = resolved.query
                 query_version = resolved.query_version
+            if resolved.requested_version:
+                requested_version = resolved.requested_version
+            else:
+                # this should only be applicable for multisearch DOIs created before VDS
+                # v6, which allowed different versions per resource; this rounds them
+                # all up to  the newest version in the list. See #187 for more detail.
+                requested_version = max(resolved.get_rounded_versions())
             return {
                 'query': query,
                 'query_version': query_version,
-                'version': resolved.requested_version,
+                'version': requested_version,
                 'resource_ids': resolved.get_resource_ids(),
                 'created': resolved.timestamp.isoformat(),
             }


### PR DESCRIPTION
This sets the resource version for the query to the newest (maximum) version of all the resources in the `resources_and_versions` dict when the `requested_version` is not set.

This is a fix for #187 that has a major caveat: the newest version in the list may not resolve to the originally intended version for all resources in the list.

This was tested on the NHM's dataset and only found to be a problem for a small number of potentially affected DOIs, and all of the affected resources were "special" resources that were loaded and versioned in a non-standard way. Obviously we are unable to test it on anyone else's implementation (if there _are_ any other usages of this extension) but from this we're relatively confident that it shouldn't be a problem for standard datasets and resources.