### PR TITLE
Allow ES parameters to be passed with search requests

### DIFF
--- a/tests/unit/lib/query/test_request.py
+++ b/tests/unit/lib/query/test_request.py
@@ -1,0 +1,19 @@
+import pytest
+
+from ckanext.versioned_datastore.lib.query.search.query import DirectQuery
+from ckanext.versioned_datastore.lib.query.search.request import SearchRequest
+
+
+class TestSearchRequest:
+    def test_add_param(self, with_vds):
+        index = 'test-1'
+        req = SearchRequest(DirectQuery([index]))
+
+        # this should fail because the index doesn't exist
+        with pytest.raises(Exception):
+            req.run()
+
+        req.add_param('ignore_unavailable', True)
+        # this should now succeed because of above parameter
+        result = req.run()
+        assert result.count == 0


### PR DESCRIPTION
Sometimes it's helpful to be able to pass parameters to ES to control the search, this feature supports doing that using the new `add_param` method on `SearchRequest`.