### PR TITLE
Ignore unavailable resources

### DIFF
--- a/ckanext/versioned_datastore/logic/multi/utils.py
+++ b/ckanext/versioned_datastore/logic/multi/utils.py
@@ -37,4 +37,8 @@ def make_request(data_dict: dict) -> SearchRequest:
         after=data_dict.get('after'),
         data_dict=data_dict,
     )
+
+    # ignore any resources that are unavailable for whatever reason
+    request.add_param('ignore_unavailable', True)
+
     return request

--- a/ckanext/versioned_datastore/theme/assets/webassets.yml
+++ b/ckanext/versioned_datastore/theme/assets/webassets.yml
@@ -4,7 +4,7 @@ datastore-activities:
   contents:
     - less/datastore-activities.less
 
-search-css:
+vds-search-css:
   output: ckanext-versioned-datastore/%(version)s_search.css
   filters: less
   contents:
@@ -16,7 +16,7 @@ download-status-css:
   contents:
     - less/download-status.less
 
-search-js:
+vds-search-js:
   output: ckanext-versioned-datastore/%(version)s_search.js
   filters: rjsmin
   contents:

--- a/ckanext/versioned_datastore/theme/templates/search/search.html
+++ b/ckanext/versioned_datastore/theme/templates/search/search.html
@@ -11,7 +11,8 @@
 {% endblock %}
 
 {% block pre_primary %}
-    {% asset 'ckanext-versioned-datastore/search' %}
+    {% asset 'ckanext-versioned-datastore/vds-search-css' %}
+    {% asset 'ckanext-versioned-datastore/vds-search-js' %}
 
     <article class="module">
         <div class="module-content">


### PR DESCRIPTION
Adds `ignore_unavailable` parameter to multisearch requests as a quick fix for "search everything" not working.

Also fixes the search asset reference.