### PR TITLE
Patch release 2025-06-09

### DIFF
--- a/ckanext/versioned_datastore/theme/templates/search/search.html
+++ b/ckanext/versioned_datastore/theme/templates/search/search.html
@@ -11,9 +11,6 @@
 {% endblock %}
 
 {% block pre_primary %}
-    {% asset 'ckanext-versioned-datastore/vds-search-css' %}
-    {% asset 'ckanext-versioned-datastore/vds-search-js' %}
-
     <article class="module">
         <div class="module-content">
             {% block search_content %}


### PR DESCRIPTION
Remove the vds-search assets to avoid a weird clash with the overriding template.

Not a breaking change because it wasn't working anyway.