### PR TITLE
Check resource exists

### DIFF
--- a/ckanext/versioned_datastore/logic/validators.py
+++ b/ckanext/versioned_datastore/logic/validators.py
@@ -58,6 +58,8 @@ def check_resource_id(resource_id: str, context: Optional[dict] = None) -> bool:
         toolkit.get_action('resource_show')(context, {'id': resource_id})
         return True
     except (toolkit.ObjectNotFound, toolkit.NotAuthorized):
+        # see ckanext-harvest@f315f41
+        context.pop('__auth_audit', None)
         return False
 
 


### PR DESCRIPTION
Fixes `check_resource_id()` so that it correctly checks that a resource exists and is accessible to the current user.

This could probably do with some tests.