### PR TITLE
fix: fix summing logic to account for arc indices

### DIFF
--- a/ckanext/versioned_datastore/logic/multi/action.py
+++ b/ckanext/versioned_datastore/logic/multi/action.py
@@ -81,12 +81,8 @@ def vds_multi_count(data_dict: dict):
     # default the counts to 0 for all resources
     counts = {resource_id: 0 for resource_id in request.query.resource_ids}
     # then update with the counts from the resources that matched the query
-    counts.update(
-        {
-            unprefix_index_name(bucket['key']): bucket['doc_count']
-            for bucket in response.aggs['counts']['buckets']
-        }
-    )
+    for bucket in response.aggs['counts']['buckets']:
+        counts[unprefix_index_name(bucket['key'])] += bucket['doc_count']
     return {'total': response.count, 'counts': counts}
 
 


### PR DESCRIPTION
If records in a resource are spread over multiple indices, the agg on _index will produce multiple results for a single resource which under the previous logic was not accounted for. This resulted in a counts dict which only contained the count for a resource from the last index iterated over containing data from that resource. This fixes this issue.

Closes: #208
