### PR TITLE
Improve performance of slug resolution action

### DIFF
--- a/ckanext/versioned_datastore/logic/slug/action.py
+++ b/ckanext/versioned_datastore/logic/slug/action.py
@@ -154,7 +154,7 @@ def vds_slug_resolve(slug: str):
 
     # check that all the resources exist and are available
     all_resource_ids = get_available_datastore_resources(
-        ignore_auth=False, user_id=toolkit.g.user
+        ignore_auth=False, user_id=getattr(toolkit.g, 'user', '')
     )
     valid_resource_ids = list(set(result['resource_ids']) & all_resource_ids)
     valid_resource_count = len(valid_resource_ids)

--- a/ckanext/versioned_datastore/logic/slug/action.py
+++ b/ckanext/versioned_datastore/logic/slug/action.py
@@ -15,8 +15,8 @@ from ckanext.versioned_datastore.lib.query.slugs.slugs import (
     resolve_slug,
 )
 from ckanext.versioned_datastore.lib.query.utils import convert_to_multisearch
+from ckanext.versioned_datastore.lib.utils import get_available_datastore_resources
 from ckanext.versioned_datastore.logic.slug import helptext, schema
-from ckanext.versioned_datastore.logic.validators import check_datastore_resource_id
 
 
 @action(schema.vds_slug_create(), helptext.vds_slug_create)
@@ -153,11 +153,10 @@ def vds_slug_resolve(slug: str):
         )
 
     # check that all the resources exist and are available
-    valid_resource_ids = [
-        resource_id
-        for resource_id in result['resource_ids']
-        if check_datastore_resource_id(resource_id)
-    ]
+    all_resource_ids = get_available_datastore_resources(
+        ignore_auth=False, user_id=toolkit.g.user
+    )
+    valid_resource_ids = list(set(result['resource_ids']) & all_resource_ids)
     valid_resource_count = len(valid_resource_ids)
     current_resource_count = len(result['resource_ids'])
     if valid_resource_count != current_resource_count:

--- a/tests/unit/logic/actions/test_actions_slug.py
+++ b/tests/unit/logic/actions/test_actions_slug.py
@@ -17,7 +17,7 @@ warnings = {
 }
 
 
-@pytest.mark.usefixtures('with_vds', 'with_vds_resource')
+@pytest.mark.usefixtures('with_request_context', 'with_vds', 'with_vds_resource')
 class TestResolveSlug:
     @patch('ckanext.versioned_datastore.logic.slug.action.resolve_slug')
     def test_resolve_slug_basic(self, mock_resolve_slug, with_vds_resource):
@@ -170,7 +170,7 @@ class TestResolveSlug:
             vds_slug_resolve('slug-does-not-exist')
 
 
-@pytest.mark.usefixtures('with_vds', 'with_vds_resource')
+@pytest.mark.usefixtures('with_request_context', 'with_vds', 'with_vds_resource')
 class TestResolveDOI:
     @patch(
         'ckanext.versioned_datastore.logic.slug.action.plugin_loaded', return_value=True


### PR DESCRIPTION
Resolving slugs/DOIs with a lot of resources is very slow because we need to make sure that they're all available in the datastore. Previously we were iterating over them and checking each one individually to make sure it exists, is accessible by the current user, and is in the datastore.

This loads a set of resource IDs from the database that are marked as `datastore_active` and checks the slug/DOI's resources against that. This means we're no longer checking against the datastore directly and therefore are relying on the database to be accurate. Not ideal, but iterating and checking directly was just way too slow.

Closes: #210