### PR TITLE
Missing user hotfix

### DIFF
--- a/ckanext/versioned_datastore/logic/validators.py
+++ b/ckanext/versioned_datastore/logic/validators.py
@@ -53,7 +53,11 @@ def url_safe(value, context):
 def check_resource_id(resource_id: str, context: Optional[dict] = None) -> bool:
     context = context.copy() if context is not None else {}
     if context.get('user') is None:
-        context['user'] = toolkit.g.get('user')
+        try:
+            context['user'] = toolkit.g.get('user')
+        except RuntimeError:
+            # during e.g. testing we don't have access to toolkit.g
+            pass
 
     # check it exists
     if not Session.query(Resource).get(resource_id):


### PR DESCRIPTION
This is to fix a bug where validate_datastore_resource_ids is *sometimes* called with an empty context, meaning that all resources are evaluated as having no access permission.
