### PR TITLE
Ingestion + caching fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,12 @@ All of this extension's actions are [fully documented](https://ckanext-versioned
 
 1. `initdb`: ensure the tables needed by this plugin exist.
     ```bash
-    ckan -c $CONFIG_FILE initdb
+    ckan -c $CONFIG_FILE versioned-datastore initdb
     ```
 
 2. `reindex`: reindex either a specific resource or all resources.
     ```bash
-    ckan -c $CONFIG_FILE reindex $OPTIONAL_RESOURCE_ID
+    ckan -c $CONFIG_FILE versioned-datastore reindex $OPTIONAL_RESOURCE_ID
     ```
 
 ## Interfaces

--- a/ckanext/versioned_datastore/cli.py
+++ b/ckanext/versioned_datastore/cli.py
@@ -2,7 +2,9 @@ from typing import Tuple
 
 import click
 from ckan.plugins import toolkit
+from ckantools.cache import CacheClearError, clear_cache_region
 
+from ckanext.versioned_datastore.lib import utils
 from ckanext.versioned_datastore.model.details import datastore_resource_details_table
 from ckanext.versioned_datastore.model.downloads import (
     datastore_downloads_core_files_table,
@@ -99,3 +101,12 @@ def reindex(resource_ids: Tuple[str], full: bool = False):
                 f'Failed to reindex {resource_id} due to validation error: {e}',
                 fg='red',
             )
+
+
+@versioned_datastore.command()
+def clear_cache():
+    try:
+        clear_cache_region('versioned_datastore', utils, cache_name='vds')
+        click.secho('Cleared vds cache', fg='green')
+    except CacheClearError as e:
+        click.secho(f'Failed to clear vds cache: {e}', fg='red')

--- a/ckanext/versioned_datastore/lib/importing/tasks.py
+++ b/ckanext/versioned_datastore/lib/importing/tasks.py
@@ -29,6 +29,7 @@ def queue_ingest(
     replace: bool,
     api_key: str,
     records: Optional[List[dict]] = None,
+    reingest: bool = False,
 ) -> Tuple[Job, Job]:
     """
     Queues a new ingest job on the importing queue for the given resource.
@@ -40,6 +41,8 @@ def queue_ingest(
         private datasets)
     :param records: optional list of dicts to ingest instead of the file/URL on the
         resource
+    :param reingest: reingest the dataset even if the new file hash matches the
+        previously ingested file hash
     :returns: a 2-tuple of the created ingest job and sync job which is dependent on the
         ingest job
     """
@@ -47,7 +50,7 @@ def queue_ingest(
         raise ReadOnlyResourceException('This resource has been marked as read only')
 
     # create the ingest task first
-    ingest_task = IngestResourceTask(resource, replace, api_key, records)
+    ingest_task = IngestResourceTask(resource, replace, api_key, records, reingest)
     ingest_job = ingest_task.queue()
 
     # then create a sync task dependent on the ingest task
@@ -121,6 +124,7 @@ class IngestResourceTask(Task):
         replace: bool,
         api_key: str,
         records: Optional[List[dict]] = None,
+        reingest: bool = False,
     ):
         """
         :param resource: the resource dict
@@ -130,18 +134,21 @@ class IngestResourceTask(Task):
                         private datasets)
         :param records: optional list of dicts to ingest instead of the resource's
                         file/URL
+        :param reingest: reingest the dataset even if the new file hash matches the
+                      previously ingested file hash
         """
         self.resource = resource
         self.replace = replace
         self.api_key = api_key
         self.records = records
+        self.reingest = reingest
 
         # create a meaningful title
         if records is not None:
             data_info = f'{len(records)} records'
         else:
             data_info = 'data from file/url'
-        title = f'Ingest for {self.resource_id} of {data_info} [replace: {replace}]'
+        title = f'Ingest for {self.resource_id} of {data_info} [replace: {replace}] [reingest: {reingest}]'
         super().__init__('importing', title)
 
     @staticmethod
@@ -177,7 +184,7 @@ class IngestResourceTask(Task):
                 source = tmpdir / 'source'
                 file_hash = download_resource_data(self.resource, source, self.api_key)
                 last_hash = get_last_file_hash(self.resource_id)
-                if file_hash == last_hash:
+                if file_hash == last_hash and not self.reingest:
                     stats.update(error=get_dupe_message(file_hash))
                     self.log.info(get_dupe_message(file_hash))
                     return

--- a/ckanext/versioned_datastore/lib/tasks.py
+++ b/ckanext/versioned_datastore/lib/tasks.py
@@ -6,9 +6,10 @@ from typing import List, Optional, Union
 
 from cachetools import TTLCache, cached
 from ckan.plugins import toolkit
+from ckantools.cache import CacheClearError, clear_cache_region
 from rq.job import Job
 
-from ckanext.versioned_datastore.lib.utils import es_client
+from ckanext.versioned_datastore.lib import utils
 
 
 class Task(abc.ABC):
@@ -44,6 +45,15 @@ class Task(abc.ABC):
         """
         ...
 
+    def post_run(self):
+        """
+        Runs immediately after self.run().
+        """
+        try:
+            clear_cache_region('versioned_datastore', utils, cache_name='vds')
+        except CacheClearError as e:
+            self.log.error(e)
+
     def start(self):
         """
         Starts the task, performs some setup and then calls self.run with a temporary
@@ -52,6 +62,7 @@ class Task(abc.ABC):
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             self.log.info(f'Starting {self.title}')
             self.run(Path(tmp_dir_name))
+        self.post_run()
         self.log.info(f'Finished {self.title}')
 
     def queue(
@@ -100,5 +111,5 @@ def get_queue_length(queue_name):
 
 @cached(cache=TTLCache(maxsize=10, ttl=300))
 def get_es_health():
-    client = es_client()
+    client = utils.es_client()
     return {'ping': client.ping(), 'info': client.info()}

--- a/ckanext/versioned_datastore/logic/data/action.py
+++ b/ckanext/versioned_datastore/logic/data/action.py
@@ -24,7 +24,11 @@ from ckanext.versioned_datastore.logic.data import helptext, schema
 
 @action(schema.vds_data_add(), helptext.vds_data_add)
 def vds_data_add(
-    context: dict, original_data_dict: dict, resource_id: str, replace: bool
+    context: dict,
+    original_data_dict: dict,
+    resource_id: str,
+    replace: bool,
+    reingest: bool = False,
 ):
     """
     Add data to the datastore for the given resource. The data added will be the data
@@ -40,6 +44,10 @@ def vds_data_add(
     data replacing the old data. This is the kind of behaviour users expect when
     uploading a fresh new file.
 
+    If the reingest flag is True, the file will be ingested even if the database
+    believes it has already ingested a file with the same file hash. This is mostly for
+    handling errors and shouldn't generally be needed.
+
     Before the ingest and sync jobs are queued, the datastore's parsing options are
     updated if required. If they are altered before ingest, the new version will be
     returned in the result dict.
@@ -47,6 +55,7 @@ def vds_data_add(
     :param context: the CKAN context
     :param resource_id: the resource ID
     :param replace: whether to replace all existing records with the new ones
+    :param reingest: whether to ingest even if the previous file is identical
     :returns: a dict containing information about the add
     """
     if is_resource_read_only(resource_id):
@@ -65,7 +74,9 @@ def vds_data_add(
     if resource.get('disable_parsing', False):
         raise RawResourceException('Ingestion has been disabled for this resource')
 
-    ingest_job, sync_job = queue_ingest(resource, replace, user['apikey'], records)
+    ingest_job, sync_job = queue_ingest(
+        resource, replace, user['apikey'], records, reingest
+    )
 
     return {
         'new_options_version': new_options_version,

--- a/ckanext/versioned_datastore/logic/data/schema.py
+++ b/ckanext/versioned_datastore/logic/data/schema.py
@@ -13,6 +13,7 @@ def vds_data_add() -> dict:
     return {
         'resource_id': [not_empty, str, resource_id_exists],
         'replace': [not_missing, boolean_validator],
+        'reingest': [ignore_missing, boolean_validator],
     }
 
 

--- a/ckanext/versioned_datastore/plugin.py
+++ b/ckanext/versioned_datastore/plugin.py
@@ -216,8 +216,77 @@ class VersionedSearchPlugin(SingletonPlugin):
             'nav_slug': helpers.nav_slug,
         }
 
-    # IResourceController
+    # IResourceController (<2.10 compatibility)
+    def before_create(self, context, resource):
+        # only in IResourceController, but renamed
+        self.before_resource_create(context, resource)
+
+    # IResourceController and IPackageController (<2.10 compatibility)
+    def after_create(self, context, data_dict=None, resource=None, pkg_dict=None):
+        data_dict = data_dict or resource or pkg_dict
+        is_resource = (resource is not None) or ('resource_type' in data_dict)
+        if is_resource:
+            self.after_resource_create(context, data_dict)
+        else:
+            self.after_dataset_create(context, data_dict)
+
+    # IResourceController (<2.10 compatibility)
     def before_show(self, resource_dict):
+        # only in IResourceController, but renamed
+        self.before_resource_show(resource_dict)
+
+    # IResourceController (<2.10 compatibility)
+    def before_update(self, context, current, resource):
+        # only in IResourceController, but renamed
+        self.before_resource_update(context, current, resource)
+
+    # IResourceController and IPackageController (<2.10 compatibility)
+    def after_update(self, context, data_dict=None, resource=None, pkg_dict=None):
+        data_dict = data_dict or resource or pkg_dict
+        is_resource = (resource is not None) or ('resource_type' in data_dict)
+        if is_resource:
+            self.after_resource_update(context, data_dict)
+        else:
+            self.after_dataset_update(context, data_dict)
+
+    # IResourceController (<2.10 compatibility)
+    def before_delete(self, context: dict, resource: dict, resources: List[dict]):
+        # only in IResourceController, but renamed
+        self.before_resource_delete(context, resource, resources)
+
+    # IResourceController and IPackageController (<2.10 compatibility)
+    def after_delete(self, context, data_obj=None, resources=None, pkg_dict=None):
+        data_obj = data_obj or resources or pkg_dict
+        is_resource = (resources is not None) or isinstance(data_obj, list)
+        if is_resource:
+            self.after_resource_delete(context, data_obj)
+        else:
+            self.after_dataset_delete(context, data_obj)
+
+    # IResourceController
+    def before_resource_create(self, context, resource):
+        # only set disable_parsing if it's True (False by default)
+        if toolkit.asbool(resource.pop('disable_parsing', False)):
+            resource['disable_parsing'] = True
+        # same for download_original_filenames
+        if toolkit.asbool(resource.pop('download_original_filenames', False)):
+            resource['download_original_filenames'] = True
+
+    # IResourceController
+    def after_resource_create(self, context: dict, resource: dict):
+        # use replace to overwrite the existing data (this is what users would expect)
+        data_dict = {'resource_id': resource['id'], 'replace': True}
+        with suppress(utils.ReadOnlyResourceException), suppress(
+            utils.RawResourceException
+        ):
+            toolkit.get_action('vds_data_add')(context, data_dict)
+        try:
+            clear_cache_region('versioned_datastore', utils, cache_name='vds')
+        except CacheClearError as e:
+            log.error(e)
+
+    # IResourceController
+    def before_resource_show(self, resource_dict):
         # ensure datastore_active is set where it should be
         resource_dict['datastore_active'] = utils.is_datastore_resource(
             resource_dict['id']
@@ -228,16 +297,7 @@ class VersionedSearchPlugin(SingletonPlugin):
         return resource_dict
 
     # IResourceController
-    def before_create(self, context, resource):
-        # only set disable_parsing if it's True (False by default)
-        if toolkit.asbool(resource.pop('disable_parsing', False)):
-            resource['disable_parsing'] = True
-        # same for download_original_filenames
-        if toolkit.asbool(resource.pop('download_original_filenames', False)):
-            resource['download_original_filenames'] = True
-
-    # IResourceController
-    def before_update(self, context, current, resource):
+    def before_resource_update(self, context, current, resource):
         # we can't automatically go from ingested to raw because it might be included
         # in queries and DOIs, but we can ingest a file that was previously raw
         was_raw = toolkit.asbool(current.get('disable_parsing', False))
@@ -250,7 +310,7 @@ class VersionedSearchPlugin(SingletonPlugin):
             resource['download_original_filenames'] = True
 
     # IResourceController
-    def after_update(self, context: dict, resource: dict):
+    def after_resource_update(self, context: dict, resource: dict):
         # use replace to overwrite the existing data (this is what users would expect)
         data_dict = {'resource_id': resource['id'], 'replace': True}
         with suppress(utils.ReadOnlyResourceException), suppress(
@@ -263,41 +323,34 @@ class VersionedSearchPlugin(SingletonPlugin):
             log.error(e)
 
     # IResourceController
-    def after_create(self, context: dict, resource: dict):
-        # use replace to overwrite the existing data (this is what users would expect)
-        data_dict = {'resource_id': resource['id'], 'replace': True}
-        with suppress(utils.ReadOnlyResourceException), suppress(
-            utils.RawResourceException
-        ):
-            toolkit.get_action('vds_data_add')(context, data_dict)
-        try:
-            clear_cache_region('versioned_datastore', utils, cache_name='vds')
-        except CacheClearError as e:
-            log.error(e)
-
-    def before_delete(self, context: dict, resource: dict, resources: List[dict]):
+    def before_resource_delete(
+        self, context: dict, resource: dict, resources: List[dict]
+    ):
         toolkit.get_action('vds_data_delete')(context, {'resource_id': resource['id']})
 
-    def after_delete(self, context: dict, resources: List[dict]):
+    # IResourceController
+    def after_resource_delete(self, context: dict, resources: List[dict]):
         try:
             clear_cache_region('versioned_datastore', utils, cache_name='vds')
         except CacheClearError as e:
             log.error(e)
 
     # IPackageController
-    def after_create(self, context: dict, pkg_dict: dict):
+    def after_dataset_create(self, context: dict, pkg_dict: dict):
         try:
             clear_cache_region('versioned_datastore', utils, cache_name='vds')
         except CacheClearError as e:
             log.error(e)
 
-    def after_update(self, context: dict, pkg_dict: dict):
+    # IPackageController
+    def after_dataset_update(self, context: dict, pkg_dict: dict):
         try:
             clear_cache_region('versioned_datastore', utils, cache_name='vds')
         except CacheClearError as e:
             log.error(e)
 
-    def after_delete(self, context: dict, pkg_dict: dict):
+    # IPackageController
+    def after_dataset_delete(self, context: dict, pkg_dict: dict):
         try:
             clear_cache_region('versioned_datastore', utils, cache_name='vds')
         except CacheClearError as e:


### PR DESCRIPTION
This includes:

- a fix for a fairly major bug introduced in ba0a3dc that resulted in no data being ingested
- the beginnings of some CKAN 2.10 compatibility (in order to fix the aforementioned bug)
- new `clear-cache` command
- cache clearing after background tasks
- new `reingest` flag for ingest task, which ignores the previous file hash and reads the file even if it's already been read (or at least, it _thinks_ it has, which is what this is for); should probably only be used with `replace = True` but I haven't enforced that

Fixing the bug from ba0a3dc will also require identifying and ingesting any resources that should have been ingested while it was live.