### PR TITLE
Adds function to helper for converting multisearch

### DIFF
--- a/ckanext/versioned_datastore/helpers.py
+++ b/ckanext/versioned_datastore/helpers.py
@@ -6,6 +6,7 @@ from ckan.plugins import toolkit
 from ckanext.versioned_datastore.lib.common import ALL_FORMATS
 from ckanext.versioned_datastore.lib.query.search.query import SchemaQuery
 from ckanext.versioned_datastore.lib.query.slugs.slugs import create_nav_slug
+from ckanext.versioned_datastore.lib.query.utils import convert_to_multisearch
 from ckanext.versioned_datastore.model import stats
 
 
@@ -167,3 +168,11 @@ def nav_slug(query=None, version=None, resource_ids=None):
     """
     is_new, slug = create_nav_slug(SchemaQuery(resource_ids, version, query))
     return slug.get_slug_string()
+
+
+def multisearch(query=None):
+    """
+    A helper proxy for convert_to_multisearch.
+    """
+    multisearch = convert_to_multisearch(query)
+    return multisearch

--- a/ckanext/versioned_datastore/plugin.py
+++ b/ckanext/versioned_datastore/plugin.py
@@ -214,6 +214,7 @@ class VersionedSearchPlugin(SingletonPlugin):
             'get_version_date': helpers.get_version_date,
             'latest_item_version': helpers.latest_item_version,
             'nav_slug': helpers.nav_slug,
+            'multisearch': helpers.multisearch,
         }
 
     # IResourceController (<2.10 compatibility)


### PR DESCRIPTION
Adds a helper for converting queries to multisearch. This allows for the redirect from the old search to the new one with the existing filter query.

Relates to:
https://github.com/NaturalHistoryMuseum/ckanext-nhm/pull/886

For:
https://github.com/NaturalHistoryMuseum/ckanext-nhm/issues/857