### PR TITLE
Fix slug rescource ids type issue

### DIFF
--- a/ckanext/versioned_datastore/logic/slug/action.py
+++ b/ckanext/versioned_datastore/logic/slug/action.py
@@ -104,8 +104,7 @@ def vds_slug_resolve(slug: str):
                 'version': resolved.version,
                 # todo: should we turn an empty resource_ids list into the list of all
                 #       available resources at this point or let it ride until query time?
-                'resource_ids': validate_datastore_resource_ids(resolved.resource_ids)
-                or [],
+                'resource_ids': resolved.resource_ids,
                 'created': resolved.created.isoformat(),
             }
         )
@@ -153,6 +152,10 @@ def vds_slug_resolve(slug: str):
             )
         )
 
+    # check the resource_ids are a list
+    resource_ids = result['resource_ids']
+    if isinstance(resource_ids, str):
+        result['resource_ids'] = resource_ids.split(',') if resource_ids else []
     # check that all the resources exist and are available
     try:
         valid_resource_ids = validate_datastore_resource_ids(result['resource_ids'])

--- a/ckanext/versioned_datastore/logic/slug/action.py
+++ b/ckanext/versioned_datastore/logic/slug/action.py
@@ -104,7 +104,8 @@ def vds_slug_resolve(slug: str):
                 'version': resolved.version,
                 # todo: should we turn an empty resource_ids list into the list of all
                 #       available resources at this point or let it ride until query time?
-                'resource_ids': resolved.resource_ids,
+                'resource_ids': validate_datastore_resource_ids(resolved.resource_ids)
+                or [],
                 'created': resolved.created.isoformat(),
             }
         )


### PR DESCRIPTION
Adds a check to vds_slug_resolve to ensure that resource_ids are always compared as lists and not string type. This resolves the issue of an unnecessary warning appearing when resource is passed as string.