### PR TITLE
Download popup

### DIFF
--- a/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
+++ b/ckanext/versioned_datastore/theme/assets/scripts/modules/download-button.js
@@ -106,6 +106,15 @@ ckan.module('versioned_datastore_download-button', function ($) {
       }
     },
 
+    _onClickOutside: function (event) {
+      // hide popover when user clicks outside
+      if ($(event.target).closest(`#${this.popoverId}`).length === 0) {
+        this.el.popover('hide');
+        // remove listener
+        $(document).off('click', this._onClickOutside);
+      }
+    },
+
     _onShowPopover: function (event) {
       // emit/publish event for other download buttons to listen to
       this.sandbox.publish('vds_dl_popover_shown', this.el);
@@ -121,6 +130,9 @@ ckan.module('versioned_datastore_download-button', function ($) {
       this.popoverForm.on('reset', () => {
         this.el.popover('hide');
       });
+
+      // hide it when the user clicks outside the popover
+      $(document).on('click', this._onClickOutside);
 
       // hide/show the email group when user changes notif type
       const notifierSelect = this.popoverForm.find('#vds-dl-notifier');

--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -35,6 +35,7 @@
                 <p><small>Should we notify you when your download is ready?</small></p>
                 <select id="vds-dl-notifier" class="full-width-input"
                         name="notifier.type">
+                    <option value="" disabled selected>Choose how you'd like to be notified</option>
                     <option value="email">
                         Email me
                     </option>
@@ -43,7 +44,7 @@
                     </option>
                 </select>
             </div>
-            <div class="form-row" id="vds-dl-email-group">
+            <div class="form-row hidden" id="vds-dl-email-group">
                 <label for="vds-dl-email">Email address</label>
                 <input id="vds-dl-email" type="email" required
                        placeholder="data@nhm.ac.uk"

--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -1,41 +1,55 @@
 <div class="vds-download-popup">
     <form>
         {% if datastore == 'true' %}
-        <p><small>More advanced download options can be found on the <a
-            href="{{ searchUrl }}" target="_blank" id="vds-dl-search-link">search page</a>.</small>
-        </p>
-        <div class="form-group">
-            <div class="form-row"><label for="vds-dl-format">File format</label>
-                <select id="vds-dl-format" class="full-width-input" name="file.format">
-                    <option value="csv">CSV/TSV</option>
-                    <option value="dwc">Darwin Core</option>
-                    <option value="json">JSON</option>
-                </select>
-            </div>
+            <p>
+                <small>
+                    More advanced download options can be found on the
+                    <a href="{{ searchUrl }}" target="_blank" id="vds-dl-search-link">
+                        search page
+                    </a>.
+                </small>
+            </p>
+            <div class="form-group">
+                <div class="form-row"><label for="vds-dl-format">File format</label>
+                    <select id="vds-dl-format" class="full-width-input" name="file.format">
+                        <option value="csv">CSV/TSV</option>
+                        <option value="dwc">Darwin Core</option>
+                        <option value="json">JSON</option>
+                    </select>
+                </div>
 
-            <div class="form-row">
-                {% if multiResource == 'true' %}
-                <div>
-                    <label for="vds-dl-sep">One file per resource</label>
-                    <input id="vds-dl-sep" type="checkbox" name="file.separate_files">
-                </div>
-                {% endif %}
-                <div>
-                    <label for="vds-dl-empty">Skip empty columns</label>
-                    <input id="vds-dl-empty" type="checkbox"
-                           name="file.ignore_empty_fields">
+                <div class="form-row">
+                    {% if multiResource == 'true' %}
+                        <div>
+                            <label for="vds-dl-sep">One file per resource</label>
+                            <input id="vds-dl-sep" type="checkbox" name="file.separate_files">
+                        </div>
+                    {% endif %}
+                    <div>
+                        <label for="vds-dl-empty">Skip empty columns</label>
+                        <input id="vds-dl-empty" type="checkbox"
+                               name="file.ignore_empty_fields">
+                    </div>
                 </div>
             </div>
-        </div>
         {% endif %}
 
         <div class="form-group">
             <div class="form-row">
                 <label for="vds-dl-notifier">Notifications</label>
-                <p><small>Downloads are not instant. Depending on size and server load, your file may take some time to generate. We can automatically notify you when your download is ready, or you can choose to check the queue yourself.</small></p>
+                <p>
+                    <small>
+                        Downloads are not instant. Depending on size and server load,
+                        your file may take some time to generate. We can automatically
+                        notify you when your download is ready, or you can choose to
+                        check the queue yourself.
+                    </small>
+                </p>
                 <select id="vds-dl-notifier" class="full-width-input"
                         name="notifier.type">
-                    <option value="" disabled selected>Choose how you'd like to be notified</option>
+                    <option value="" disabled selected>
+                        Choose how you'd like to be notified
+                    </option>
                     <option value="email">
                         Email me
                     </option>
@@ -73,7 +87,7 @@
 
     <div id="vds-dl-post-submit" class="hidden">
         <p>Your download has been queued. You can follow its progress at the link
-           below:</p>
+            below:</p>
         <a href="#" class="btn btn-primary" id="vds-dl-status-link" target="_blank"><i
             class="fas fa-hourglass-half"></i>
             Download status

--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -62,7 +62,7 @@
 
         <div>
             <button type="submit" class="btn btn-primary" id="vds-dl-submit">
-                <i class="fas fa-download"></i> {{ _('Submit') }}
+                <i class="fas fa-download"></i> {{ _('Start') }}
             </button>
             <button type="reset" class="btn btn-warning" id="vds-dl-cancel">
                 <i class="fas fa-times"></i> {{ _('Cancel') }}

--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -32,7 +32,7 @@
         <div class="form-group">
             <div class="form-row">
                 <label for="vds-dl-notifier">Notifications</label>
-                <p><small>Should we notify you when your download is ready?</small></p>
+                <p><small>Downloads are not instant. Depending on size and server load, your file may take some time to generate. We can automatically notify you when your download is ready, or you can choose to check the queue yourself.</small></p>
                 <select id="vds-dl-notifier" class="full-width-input"
                         name="notifier.type">
                     <option value="" disabled selected>Choose how you'd like to be notified</option>

--- a/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
+++ b/ckanext/versioned_datastore/theme/templates/ajax_snippets/download_popup.html
@@ -39,7 +39,7 @@
                         Email me
                     </option>
                     <option value="none">
-                        I'll check the download status manually
+                        No notification (check status manually)
                     </option>
                 </select>
             </div>


### PR DESCRIPTION
- changes submit button text from "submit" to "start"; the main search UI version in NaturalHistoryMuseum/ckanext-nhm#906 uses "start download" but this is a smaller space
- changes wording of no notification option to make it clearer
- forces user to choose a notification option instead of defaulting to email (because users then assume email is required)
- expands help text to clarify why we need to do this instead of just giving the user a download link immediately
- bonus fix: dismisses the popup when the user clicks outside instead of making them click "cancel" or the download button again

Closes: #259 
